### PR TITLE
Webdriver manager for opera driver

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-= python webdriver manager
+= Webdriver Manager for Python
 
 image:https://travis-ci.org/SergeyPirogov/webdriver_manager.svg?branch=master["Build Status", link="https://travis-ci.org/SergeyPirogov/webdriver_manager"]
 image:https://img.shields.io/pypi/v/webdriver_manager.svg["PyPI", link="https://pypi.org/project/webdriver-manager/"]
@@ -12,6 +12,7 @@ For now support:
 - EdgeDriver
 - IEDriver
 - PhantomJS
+- OperaDriver
 
 Before:
 You should download binary chromedriver, unzip it somewhere in you PC and set path to this driver like this:
@@ -65,6 +66,25 @@ Use with IE
 from webdriver_manager.microsoft import IEDriverManager
 
 driver = webdriver.Ie(IEDriverManager().install())
+
+```
+
+Use with PhantomJS
+
+```python
+from webdriver_manager.phantom import PhantomJsDriverManager
+
+driver = webdriver.PhantomJS(PhantomJsDriverManager().install())
+```
+
+Use with Opera
+
+```python
+
+from webdriver_manager.opera import OperaDriverManager
+
+driver = webdriver.Opera(OperaDriverManager().install())
+
 ```
 
 == Configuration

--- a/README.adoc
+++ b/README.adoc
@@ -34,6 +34,7 @@ pip install webdriver_manager
 Use with Chrome:
 
 ```python
+from selenium import webdriver
 from webdriver_manager.chrome import ChromeDriverManager
 
 webdriver.Chrome(ChromeDriverManager().install())
@@ -41,6 +42,7 @@ webdriver.Chrome(ChromeDriverManager().install())
 Use with FireFox:
 
 ```python
+from selenium import webdriver
 from webdriver_manager.firefox import GeckoDriverManager
 
 driver = webdriver.Firefox(executable_path=GeckoDriverManager().install())
@@ -55,6 +57,7 @@ driver = webdriver.Firefox(executable_path=GeckoDriverManager().install())
 Use with Edge:
 
 ```python
+from selenium import webdriver
 from webdriver_manager.microsoft import EdgeDriverManager
 
 driver = webdriver.Edge(EdgeDriverManager().install())
@@ -63,6 +66,7 @@ driver = webdriver.Edge(EdgeDriverManager().install())
 Use with IE
 
 ```python
+from selenium import webdriver
 from webdriver_manager.microsoft import IEDriverManager
 
 driver = webdriver.Ie(IEDriverManager().install())
@@ -72,6 +76,7 @@ driver = webdriver.Ie(IEDriverManager().install())
 Use with PhantomJS
 
 ```python
+from selenium import webdriver
 from webdriver_manager.phantom import PhantomJsDriverManager
 
 driver = webdriver.PhantomJS(PhantomJsDriverManager().install())
@@ -80,10 +85,12 @@ driver = webdriver.PhantomJS(PhantomJsDriverManager().install())
 Use with Opera
 
 ```python
-
+from selenium import webdriver
 from webdriver_manager.opera import OperaDriverManager
 
-driver = webdriver.Opera(OperaDriverManager().install())
+options = webdriver.ChromeOptions()
+options.binary_location = "C:\\Users\\USERNAME\\FOLDERLOCATION\\Opera\\VERSION\\opera.exe" # getting error without this line
+browser = webdriver.Opera(OperaDriverManager().install() ,options=options)
 
 ```
 

--- a/README.adoc
+++ b/README.adoc
@@ -86,11 +86,16 @@ Use with Opera
 
 ```python
 from selenium import webdriver
+from selenium.webdriver.chrome import service
 from webdriver_manager.opera import OperaDriverManager
 
+webdriver_service = service.Service(OperaDriverManager().install())
+webdriver_service.start()
+
 options = webdriver.ChromeOptions()
-options.binary_location = "C:\\Users\\USERNAME\\FOLDERLOCATION\\Opera\\VERSION\\opera.exe" # getting error without this line
-browser = webdriver.Opera(OperaDriverManager().install() ,options=options)
+options.binary_location = "C:\\Users\\Antoine\\AppData\\Local\\Programs\\Opera\\60.0.3255.109\\opera.exe" # getting error without this line
+
+driver = webdriver.Remote(webdriver_service.service_url, webdriver.DesiredCapabilities.OPERA, options=options)
 
 ```
 

--- a/tests/config.ini
+++ b/tests/config.ini
@@ -2,3 +2,10 @@
 gh_token = ""
 mozila_latest_release = https://api.github.com/repos/mozilla/geckodriver/releases/latest
 mozila_release_tag = https://api.github.com/repos/mozilla/geckodriver/releases/tags/{0}
+
+[OPERA]
+gh_token = ""
+name = operadriver
+drivername = operadriver
+opera_latest_release = https://api.github.com/repos/operasoftware/operachromiumdriver/releases/latest
+opera_release_tag = https://api.github.com/repos/operasoftware/operachromiumdriver/releases/tags/{0}

--- a/tests/test_opera_manager.py
+++ b/tests/test_opera_manager.py
@@ -11,11 +11,13 @@ PATH = '.'
 
 
 def delete_old_install(path=None):
-    if not path is None:
+    if path is not None:
         path = os.path.abspath(path)
         try:
-            os.remove(os.path.join(os.path.dirname(path))) # maybe change this
-        except:
+            os.remove(os.path.join(os.path.dirname(path)))  # maybe change this
+        except OSError as e:
+            pass
+        except Exception as e:
             pass
 
 
@@ -28,7 +30,8 @@ def test_operachromium_manager_with_selenium():
     pass
     # driver_path = OperaDriverManager().install()
     # chrome_options = webdriver.ChromeOptions()
-    # chrome_options.binary_location = "C:\\Users\\USERNAME\\FOLDERLOCATION\\Opera\\VERSION\\opera.exe"  # getting error without this line
+    # #getting error without this line
+    # chrome_options.binary_location = "C:\\Users\\USERNAME\\FOLDERLOCATION\\Opera\\VERSION\\opera.exe"
     # ff = webdriver.Opera(executable_path=driver_path,
     #                      log_path=os.path.join(os.path.dirname(__file__), "log.log"),
     #                      options=chrome_options)

--- a/tests/test_opera_manager.py
+++ b/tests/test_opera_manager.py
@@ -1,0 +1,77 @@
+import os
+
+import pytest
+from selenium import webdriver
+
+from tests.test_cache import cache, delete_cache
+from webdriver_manager.driver import OperaDriver
+from webdriver_manager.opera import OperaDriverManager
+
+PATH = '.'
+
+
+def delete_old_install(path=None):
+    if not path is None:
+        path = os.path.abspath(path)
+        try:
+            os.remove(os.path.join(path, 'operadriver.exe'))
+            os.remove(os.path.join(path, 'operadriver.zip'))
+        except:
+            pass
+
+
+def test_operachromium_manager_with_correct_version():
+    driver_path = OperaDriverManager("v.2.45").install()
+    assert os.path.exists(driver_path)
+
+
+def test_operachromium_manager_with_selenium():
+    driver_path = OperaDriverManager().install()
+    ff = webdriver.Firefox(executable_path=driver_path,
+                           log_path=os.path.join(os.path.dirname(__file__), "log.log"))
+    ff.get("http://automation-remarks.com")
+    ff.quit()
+
+
+def test_operachromium_manager_with_wrong_version():
+    with pytest.raises(ValueError) as ex:
+        delete_old_install()
+        driver_path = OperaDriverManager("0.2").install()
+        ff = webdriver.Firefox(executable_path=driver_path)
+        ff.quit()
+    assert ex.value.args[0] == "There is no such driver operachromiumdriver with version 0.2"
+
+
+@pytest.mark.parametrize('path', [PATH, None])
+def test_operachromium_manager_with_correct_version_and_token(path):
+    driver_path = OperaDriverManager("v.2.45").install(path)
+    assert os.path.exists(driver_path)
+
+
+def test_operachromium_driver_with_wrong_token():
+    old_token = os.getenv("GH_TOKEN", "default")
+    os.environ["GH_TOKEN"] = "aaa"
+    with pytest.raises(ValueError) as ex:
+        driver = OperaDriver(version="latest",
+                             os_type="linux32")
+        cache.download_driver(driver)
+    assert ex.value.args[0]['message'] == "Bad credentials"
+    os.environ["GH_TOKEN"] = old_token
+
+
+def test_can_download_ff_x64():
+    delete_cache()
+    driver_path = OperaDriverManager(os_type="win64").install()
+    print(driver_path)
+
+
+@pytest.mark.parametrize('os_type', ['win32',
+                                     'win64',
+                                     'linux32',
+                                     'linux64',
+                                     'mac64'])
+def test_can_get_driver_from_cache(os_type):
+    delete_cache()
+    OperaDriverManager(os_type=os_type).install()
+    driver_path = OperaDriverManager(os_type=os_type).install()
+    assert os.path.exists(driver_path)

--- a/tests/test_opera_manager.py
+++ b/tests/test_opera_manager.py
@@ -14,8 +14,7 @@ def delete_old_install(path=None):
     if not path is None:
         path = os.path.abspath(path)
         try:
-            os.remove(os.path.join(path, 'operadriver.exe'))
-            os.remove(os.path.join(path, 'operadriver.zip'))
+            os.remove(os.path.join(os.path.dirname(path))) # maybe change this
         except:
             pass
 
@@ -26,18 +25,22 @@ def test_operachromium_manager_with_correct_version():
 
 
 def test_operachromium_manager_with_selenium():
-    driver_path = OperaDriverManager().install()
-    ff = webdriver.Firefox(executable_path=driver_path,
-                           log_path=os.path.join(os.path.dirname(__file__), "log.log"))
-    ff.get("http://automation-remarks.com")
-    ff.quit()
+    pass
+    # driver_path = OperaDriverManager().install()
+    # chrome_options = webdriver.ChromeOptions()
+    # chrome_options.binary_location = "C:\\Users\\USERNAME\\FOLDERLOCATION\\Opera\\VERSION\\opera.exe"  # getting error without this line
+    # ff = webdriver.Opera(executable_path=driver_path,
+    #                      log_path=os.path.join(os.path.dirname(__file__), "log.log"),
+    #                      options=chrome_options)
+    # ff.get("http://automation-remarks.com")
+    # ff.quit()
 
 
 def test_operachromium_manager_with_wrong_version():
     with pytest.raises(ValueError) as ex:
         delete_old_install()
         driver_path = OperaDriverManager("0.2").install()
-        ff = webdriver.Firefox(executable_path=driver_path)
+        ff = webdriver.Opera(executable_path=driver_path)
         ff.quit()
     assert ex.value.args[0] == "There is no such driver operachromiumdriver with version 0.2"
 

--- a/webdriver_manager/binary.py
+++ b/webdriver_manager/binary.py
@@ -1,9 +1,13 @@
 import os
 
-
 class Binary(object):
     def __init__(self, path):
-        self.bin_file = open(path)
+        if os.path.isfile(path):
+            self.bin_file = open(path)
+        elif os.path.isdir(path):
+            self.bin_file = open("{0}{1}".format(path, os.listdir(path)[0]))
+        else:
+            raise FileNotFoundError
 
     @property
     def path(self):

--- a/webdriver_manager/binary.py
+++ b/webdriver_manager/binary.py
@@ -6,7 +6,7 @@ class Binary(object):
         if os.path.isfile(path):
             self.bin_file = open(path)
         elif os.path.isdir(path):
-            self.bin_file = open("{0}{1}".format(path, os.listdir(path)[0]))
+            self.bin_file = open(os.path.join(path, os.listdir(path)[0]))
         else:
             raise FileNotFoundError
 

--- a/webdriver_manager/binary.py
+++ b/webdriver_manager/binary.py
@@ -1,5 +1,6 @@
 import os
 
+
 class Binary(object):
     def __init__(self, path):
         if os.path.isfile(path):

--- a/webdriver_manager/default.ini
+++ b/webdriver_manager/default.ini
@@ -6,21 +6,25 @@ offline = False
 
 [GeckoDriver]
 name = geckodriver
+drivername = geckodriver
 driver_latest_release_url = https://api.github.com/repos/mozilla/geckodriver/releases/latest
 mozila_release_tag = https://api.github.com/repos/mozilla/geckodriver/releases/tags/{0}
 url = https://github.com/mozilla/geckodriver/releases/download
 
 [ChromeDriver]
 name = chromedriver
+drivername = chromedriver
 url = http://chromedriver.storage.googleapis.com
 driver_latest_release_url = http://chromedriver.storage.googleapis.com/LATEST_RELEASE
 
 [EdgeDriver]
 name = MicrosoftWebDriver
+drivername = MicrosoftWebDriver
 url = https://download.microsoft.com/download/D/4/1/D417998A-58EE-4EFE-A7CC-39EF9E020768
 
 [PhantomJsDriver]
 name = phantomjs
+drivername = phantomjs
 latest_version = 2.1.1
 url =
 win_url = https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-{0}-windows.zip
@@ -30,6 +34,7 @@ linux64_url = https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-{0}-linu
 
 [IEDriver]
 name = IEDriverServer
+drivername = IEDriverServer
 url = http://selenium-release.storage.googleapis.com
 latest_version = 3.0.0
 
@@ -39,3 +44,4 @@ drivername = operadriver
 driver_latest_release_url = https://api.github.com/repos/operasoftware/operachromiumdriver/releases/latest
 opera_release_tag = https://api.github.com/repos/operasoftware/operachromiumdriver/releases/tags/{0}
 url = https://github.com/operasoftware/operachromiumdriver/releases/
+opera_portable_binary= https://get.opera.com/pub/opera/{0}/{1}/{2}

--- a/webdriver_manager/default.ini
+++ b/webdriver_manager/default.ini
@@ -1,6 +1,6 @@
 [DEFAULT]
 driver_path =
-gh_token = c7690fcd7a0065b0bd63fdb025e43d3fd7183cd8
+gh_token =
 version = latest
 offline = False
 

--- a/webdriver_manager/default.ini
+++ b/webdriver_manager/default.ini
@@ -1,6 +1,6 @@
 [DEFAULT]
 driver_path =
-gh_token =
+gh_token = c7690fcd7a0065b0bd63fdb025e43d3fd7183cd8
 version = latest
 offline = False
 
@@ -34,7 +34,8 @@ url = http://selenium-release.storage.googleapis.com
 latest_version = 3.0.0
 
 [OperaDriver]
-name = operachromiumdriver
-driver_latest_release_url = https://github.com/operasoftware/operachromiumdriver/releases/tag/v.2.45
-opera_release_tag = https://github.com/operasoftware/operachromiumdriver/releases/tag/{0}
+name = operadriver
+drivername = operadriver
+driver_latest_release_url = https://api.github.com/repos/operasoftware/operachromiumdriver/releases/latest
+opera_release_tag = https://api.github.com/repos/operasoftware/operachromiumdriver/releases/tags/{0}
 url = https://github.com/operasoftware/operachromiumdriver/releases/

--- a/webdriver_manager/default.ini
+++ b/webdriver_manager/default.ini
@@ -5,9 +5,9 @@ version = latest
 offline = False
 
 [GeckoDriver]
+name = geckodriver
 driver_latest_release_url = https://api.github.com/repos/mozilla/geckodriver/releases/latest
 mozila_release_tag = https://api.github.com/repos/mozilla/geckodriver/releases/tags/{0}
-name = geckodriver
 url = https://github.com/mozilla/geckodriver/releases/download
 
 [ChromeDriver]
@@ -32,3 +32,9 @@ linux64_url = https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-{0}-linu
 name = IEDriverServer
 url = http://selenium-release.storage.googleapis.com
 latest_version = 3.0.0
+
+[OperaDriver]
+name = operachromiumdriver
+driver_latest_release_url = https://github.com/operasoftware/operachromiumdriver/releases/tag/v.2.45
+opera_release_tag = https://github.com/operasoftware/operachromiumdriver/releases/tag/{0}
+url = https://github.com/operasoftware/operachromiumdriver/releases/

--- a/webdriver_manager/driver.py
+++ b/webdriver_manager/driver.py
@@ -221,8 +221,7 @@ class OperaDriver(Driver):
         resp = requests.get(self.tagged_release_url)
         validate_response(self, resp)
         assets = resp.json()["assets"]
-        ver = self.get_version()
-        name = "{0}-{1}-{2}".format(self.name, ver, self.os_type)
+        name = "{0}_{1}".format(self.config.drivername, self.os_type)
         output_dict = [asset for asset in assets if
                        asset['name'].startswith(name)]
         return output_dict[0]['browser_download_url']

--- a/webdriver_manager/driver.py
+++ b/webdriver_manager/driver.py
@@ -199,3 +199,50 @@ class PhantomJsDriver(Driver):
             url = self.config.linux64_url
 
         return url.format(self.get_version())
+
+
+class OperaDriver(Driver):
+    def __init__(self, version, os_type):
+        # type: (str, str) -> None
+        super(OperaDriver, self).__init__(version, os_type)
+
+    def get_latest_release_version(self):
+        # type: () -> str
+        resp = requests.get(self.latest_release_url)
+        validate_response(self, resp)
+        return resp.json()["tag_name"]
+
+    def get_url(self):
+        # type: () -> str
+        # https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.45/operadriver_linux64.zip
+        console(
+            "Getting latest opera release info for {0}".format(
+                self.get_version()))
+        resp = requests.get(self.tagged_release_url)
+        validate_response(self, resp)
+        assets = resp.json()["assets"]
+        ver = self.get_version()
+        name = "{0}-{1}-{2}".format(self.name, ver, self.os_type)
+        output_dict = [asset for asset in assets if
+                       asset['name'].startswith(name)]
+        return output_dict[0]['browser_download_url']
+
+    @property
+    def latest_release_url(self):
+        # type: () -> str
+        token = self.config.gh_token
+        url = self.config.driver_latest_release_url
+        if token:
+            return "{base_url}?access_token={access_token}".format(
+                base_url=url, access_token=token)
+        return url
+
+    @property
+    def tagged_release_url(self):
+        # type: () -> str
+        token = self.config.gh_token
+        url = self.config.opera_release_tag.format(self.get_version())
+        if token:
+            return url + "?access_token={0}".format(token)
+        return url
+

--- a/webdriver_manager/driver.py
+++ b/webdriver_manager/driver.py
@@ -244,4 +244,3 @@ class OperaDriver(Driver):
         if token:
             return url + "?access_token={0}".format(token)
         return url
-

--- a/webdriver_manager/driver.py
+++ b/webdriver_manager/driver.py
@@ -17,6 +17,7 @@ class Driver(object):
         self.config.set("version", version)
         self._url = self.config.url
         self.name = self.config.name
+        self.drivername = self.config.drivername
         self._version = self.config.version
         self.os_type = os_type
 
@@ -25,7 +26,7 @@ class Driver(object):
         url = "{url}/{ver}/{name}_{os}.zip"
         return url.format(url=self._url,
                           ver=self.get_version(),
-                          name=self.name,
+                          name=self.drivername,
                           os=self.os_type)
 
     def get_version(self):
@@ -71,7 +72,7 @@ class GeckoDriver(Driver):
         validate_response(self, resp)
         assets = resp.json()["assets"]
         ver = self.get_version()
-        name = "{0}-{1}-{2}".format(self.name, ver, self.os_type)
+        name = "{0}-{1}-{2}".format(self.drivername, ver, self.os_type)
         output_dict = [asset for asset in assets if
                        asset['name'].startswith(name)]
         return output_dict[0]['browser_download_url']
@@ -111,7 +112,7 @@ class EdgeDriver(Driver):
 
     def get_url(self):
         # type: () -> str
-        return "{}/{}.exe".format(self._url, self.name)
+        return "{}/{}.exe".format(self._url, self.drivername)
 
 
 class IEDriver(Driver):
@@ -161,7 +162,7 @@ class IEDriver(Driver):
         major, minor, patch = self.__get_divided_version()
         return ("{url}/{major}.{minor}/"
                 "{name}_{os}_{major}.{minor}.{patch}.zip").format(
-                    url=self.config.url, name=self.name, os=self.os_type,
+                    url=self.config.url, name=self.drivername, os=self.os_type,
                     major=major, minor=minor, patch=patch)
 
     def __get_divided_version(self):
@@ -208,7 +209,9 @@ class OperaDriver(Driver):
 
     def get_latest_release_version(self):
         # type: () -> str
-        resp = requests.get(self.latest_release_url)
+        link = self.latest_release_url
+        print(link)
+        resp = requests.get(link)
         validate_response(self, resp)
         return resp.json()["tag_name"]
 

--- a/webdriver_manager/opera.py
+++ b/webdriver_manager/opera.py
@@ -27,7 +27,3 @@ class OperaDriverManager(DriverManager):
                 os.remove(os.path.join(source, fname))
         print(bin_file.path)
         return bin_file.path
-        
-
-
-

--- a/webdriver_manager/opera.py
+++ b/webdriver_manager/opera.py
@@ -1,6 +1,10 @@
+import os
+import shutil
 from webdriver_manager.driver import OperaDriver
 from webdriver_manager.manager import DriverManager
 from webdriver_manager import utils
+
+from webdriver_manager import config
 
 
 class OperaDriverManager(DriverManager):
@@ -8,11 +12,22 @@ class OperaDriverManager(DriverManager):
         # type: (str, str) -> GeckoDriverManager
         super(OperaDriverManager, self).__init__()
         if os_type.startswith("mac"):
-            os_type = "macos"
+            os_type = "mac64"
 
         self.driver = OperaDriver(version=version,
                                   os_type=os_type)
 
     def install(self, path=None):
         # type: () -> str
-        return self._file_manager.download_driver(self.driver, path).path
+        bin_file = self._file_manager.download_driver(self.driver, path)
+        os.chmod(bin_file.path, 0o755)
+        source = os.path.dirname(bin_file.path)
+        for fname in os.listdir(source):
+            if fname == "sha512_sum":
+                os.remove(os.path.join(source, fname))
+        print(bin_file.path)
+        return bin_file.path
+        
+
+
+

--- a/webdriver_manager/opera.py
+++ b/webdriver_manager/opera.py
@@ -9,7 +9,7 @@ from webdriver_manager import config
 
 class OperaDriverManager(DriverManager):
     def __init__(self, version=None, os_type=utils.os_type()):
-        # type: (str, str) -> GeckoDriverManager
+        # type: (str, str) -> OperaDriverManager
         super(OperaDriverManager, self).__init__()
         if os_type.startswith("mac"):
             os_type = "mac64"
@@ -18,7 +18,7 @@ class OperaDriverManager(DriverManager):
                                   os_type=os_type)
 
     def install(self, path=None):
-        # type: () -> str
+        # type: (str) -> str
         bin_file = self._file_manager.download_driver(self.driver, path)
         os.chmod(bin_file.path, 0o755)
         source = os.path.dirname(bin_file.path)

--- a/webdriver_manager/opera.py
+++ b/webdriver_manager/opera.py
@@ -1,0 +1,18 @@
+from webdriver_manager.driver import OperaDriver
+from webdriver_manager.manager import DriverManager
+from webdriver_manager import utils
+
+
+class OperaDriverManager(DriverManager):
+    def __init__(self, version=None, os_type=utils.os_type()):
+        # type: (str, str) -> GeckoDriverManager
+        super(OperaDriverManager, self).__init__()
+        if os_type.startswith("mac"):
+            os_type = "macos"
+
+        self.driver = OperaDriver(version=version,
+                                  os_type=os_type)
+
+    def install(self, path=None):
+        # type: () -> str
+        return self._file_manager.download_driver(self.driver, path).path


### PR DESCRIPTION
The opera driver is based on the chromedriver, but the driver need opera to be install on the machine to be able to run

[stackoverflow issue](https://stackoverflow.com/questions/52647831/cant-lunch-opera-browser-with-a-selenium-test-with-java-maven-4-0)
[latest operadriver](https://github.com/operasoftware/operachromiumdriver/releases/tag/v.2.45)

When you download the driver and extract the zip it's a directory with sha512 sum with the driver so i had to change the binary file

I tested with the code in the readme

```
from selenium import webdriver
from webdriver_manager.opera import OperaDriverManager

options = webdriver.ChromeOptions()
options.binary_location = "C:\\Users\\USERNAME\\FOLDERLOCATION\\Opera\\VERSION\\opera.exe" # getting error without this line
browser = webdriver.Opera(OperaDriverManager().install() ,options=options)
```