### PR TITLE
Fix Travis-CI fails at master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ celerybeat-schedule
 .env
 
 # virtualenv
+.venv/
 venv/
 ENV/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: bionic
 addons:
   firefox: latest
   chrome: stable
+services: xvfb
 language: python
 python:
 - '3.6'
@@ -12,10 +13,6 @@ before_install:
 - sudo add-apt-repository "deb [arch=i386,amd64] https://deb.opera.com/opera-stable/ stable non-free"
 - sudo apt-get update -y
 - sudo apt install opera-stable
-- export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start
-- "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile
-  --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
 
 install:
 - pip install pipenv

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: bionic
 addons:
   firefox: latest
   chrome: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
   directories:
     - $HOME/.wdm/drivers
     - ./drivers
-    - ./custom
+    - ./custom/drivers
 
 before_install:
 - wget -qO- https://deb.opera.com/archive.key | sudo apt-key add -

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ cache:
   directories:
     - $HOME/.wdm/drivers
     - ./drivers
+    - ./custom
 
 before_install:
 - wget -qO- https://deb.opera.com/archive.key | sudo apt-key add -

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,9 @@ python:
 cache:
   directories:
     - $HOME/.wdm/drivers
-    - ./drivers
     - ./custom/drivers
+    - ./.wdm/drivers
+    - ./drivers
 
 before_install:
 - wget -qO- https://deb.opera.com/archive.key | sudo apt-key add -

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ python:
 - '3.6'
 
 before_install:
-- git config github-oauth.github.com ${GH_TOKEN}
 - wget -qO- https://deb.opera.com/archive.key | sudo apt-key add -
 - sudo add-apt-repository "deb [arch=i386,amd64] https://deb.opera.com/opera-stable/ stable non-free"
 - sudo apt-get update -y

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: xenial
+dist: bionic
 addons:
   firefox: latest
   chrome: stable
@@ -12,7 +12,7 @@ before_install:
 - wget -qO- https://deb.opera.com/archive.key | sudo apt-key add -
 - sudo add-apt-repository "deb [arch=i386,amd64] https://deb.opera.com/opera-stable/ stable non-free"
 - sudo apt-get update -y
-- sudo apt-get -y install opera-stable
+- sudo apt-get -y --no-install-recommends install opera-stable
 
 install:
 - pip install pipenv

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ cache:
   directories:
     - $HOME/.wdm/drivers/
     - $HOME/custom/
+    - /home/travis/.wdm/
     - ./.wdm/drivers/
     - ./custom/drivers/
     - ./tests/drivers/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,10 @@ python:
 - '3.6'
 
 before_install:
-- $GH_TOKEN
 - wget -qO- https://deb.opera.com/archive.key | sudo apt-key add -
 - sudo add-apt-repository "deb [arch=i386,amd64] https://deb.opera.com/opera-stable/ stable non-free"
 - sudo apt-get update -y
-- sudo apt install opera-stable
+- sudo apt-get -y install opera-stable
 
 install:
 - pip install pipenv

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ language: python
 python:
 - '3.6'
 
+cache:
+  directories:
+    - $HOME/.wdm/drivers
+    - ./drivers
+
 before_install:
 - wget -qO- https://deb.opera.com/archive.key | sudo apt-key add -
 - sudo add-apt-repository "deb [arch=i386,amd64] https://deb.opera.com/opera-stable/ stable non-free"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
 - '3.6'
 
 before_install:
+- git config github-oauth.github.com ${GH_TOKEN}
 - wget -qO- https://deb.opera.com/archive.key | sudo apt-key add -
 - sudo add-apt-repository "deb [arch=i386,amd64] https://deb.opera.com/opera-stable/ stable non-free"
 - sudo apt-get update -y

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: bionic
+dist: xenial
 addons:
   firefox: latest
   chrome: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ cache:
     - ./.wdm/drivers/
     - ./custom/drivers/
     - ./drivers/
+    - drivers/
 
 before_install:
 - wget -qO- https://deb.opera.com/archive.key | sudo apt-key add -

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ python:
 - '3.6'
 
 before_install:
+- composer self-update -q
+- if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
+- composer show -i
 - wget -qO- https://deb.opera.com/archive.key | sudo apt-key add -
 - sudo add-apt-repository "deb [arch=i386,amd64] https://deb.opera.com/opera-stable/ stable non-free"
 - sudo apt-get update -y

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ python:
 cache:
   directories:
     - $HOME/.wdm/drivers/
+    - $HOME/custom/
     - ./.wdm/drivers/
     - ./custom/drivers/
     - ./tests/drivers/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ cache:
     - $HOME/.wdm/drivers/
     - ./.wdm/drivers/
     - ./custom/drivers/
+    - ./tests/drivers/
     - ./drivers/
-    - drivers/
 
 before_install:
 - wget -qO- https://deb.opera.com/archive.key | sudo apt-key add -

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ python:
 
 cache:
   directories:
-    - $HOME/.wdm/drivers
-    - ./custom/drivers
-    - ./.wdm/drivers
-    - ./drivers
+    - $HOME/.wdm/drivers/
+    - ./.wdm/drivers/
+    - ./custom/drivers/
+    - ./drivers/
 
 before_install:
 - wget -qO- https://deb.opera.com/archive.key | sudo apt-key add -

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,7 @@ python:
 - '3.6'
 
 before_install:
-- composer self-update -q
-- if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
-- composer show -i
+- $GH_TOKEN
 - wget -qO- https://deb.opera.com/archive.key | sudo apt-key add -
 - sudo add-apt-repository "deb [arch=i386,amd64] https://deb.opera.com/opera-stable/ stable non-free"
 - sudo apt-get update -y

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     name='webdriver_manager',
     packages=setuptools.find_packages(exclude=['tests']),
     include_package_data=True,
-    version='2.2.0',
+    version='2.3.0',
     description=('Library provides the way to automatically manage drivers for different browsers'),
     author='Sergey Pirogov',
     author_email='automationremarks@gmail.com',

--- a/tests/test_firefox_manager.py
+++ b/tests/test_firefox_manager.py
@@ -5,18 +5,6 @@ from selenium import webdriver
 
 from webdriver_manager.firefox import GeckoDriverManager
 
-PATH = '.'
-
-
-def delete_old_install(path=None):
-    if path is not None:
-        path = os.path.abspath(path)
-        try:
-            os.remove(os.path.join(path, 'geckodriver.exe'))
-            os.remove(os.path.join(path, 'geckodriver.zip'))
-        except:
-            pass
-
 
 def test_gecko_manager_with_selenium():
     driver_path = GeckoDriverManager().install()
@@ -27,7 +15,6 @@ def test_gecko_manager_with_selenium():
 
 def test_gecko_manager_with_wrong_version():
     with pytest.raises(ValueError) as ex:
-        delete_old_install()
         driver_path = GeckoDriverManager("0.2").install()
         ff = webdriver.Firefox(executable_path=driver_path)
         ff.quit()
@@ -35,7 +22,7 @@ def test_gecko_manager_with_wrong_version():
            ex.value.args[0]
 
 
-@pytest.mark.parametrize('path', [PATH, None])
+@pytest.mark.parametrize('path', ['.', None])
 def test_gecko_manager_with_correct_version_and_token(path):
     driver_path = GeckoDriverManager(version="v0.11.0", path=path).install()
     assert os.path.exists(driver_path)

--- a/tests/test_opera_manager.py
+++ b/tests/test_opera_manager.py
@@ -1,29 +1,11 @@
-import os
-import shutil
 import glob
+import os
 
 import pytest
 from selenium import webdriver
-from selenium.webdriver.chrome import service
 
-from webdriver_manager.driver import OperaDriver
 from webdriver_manager.opera import OperaDriverManager
 from webdriver_manager.utils import os_type as get_os_type
-
-PATH = '.'
-
-
-def delete_old_install(path=None):
-    if path is not None:
-        path = os.path.abspath(path)
-    os_type = get_os_type()
-    try:
-        os.remove(os.path.join(path, 'operadriver_{}.zip'.format(os_type)))
-        shutil.rmtree(os.path.join(path, 'operadriver_{}'.format(os_type)))
-    except OSError:
-        pass
-    except Exception:
-        pass
 
 
 def test_opera_driver_manager_with_correct_version():
@@ -55,16 +37,15 @@ def test_operadriver_manager_with_selenium():
 
 def test_opera_driver_manager_with_wrong_version():
     with pytest.raises(ValueError) as ex:
-        delete_old_install(PATH)
         driver_path = OperaDriverManager("0.2").install()
         ff = webdriver.Opera(executable_path=driver_path)
         ff.quit()
-    assert  "There is no such driver by url "\
-        "https://api.github.com/repos/operasoftware/operachromiumdriver/"\
-        "releases/tags/0.2" in ex.value.args[0]
+    assert "There is no such driver by url " \
+           "https://api.github.com/repos/operasoftware/operachromiumdriver/" \
+           "releases/tags/0.2" in ex.value.args[0]
 
 
-@pytest.mark.parametrize('path', [PATH, None])
+@pytest.mark.parametrize('path', ['.', None])
 def test_opera_driver_manager_with_correct_version_and_token(path):
     driver_path = OperaDriverManager(version="v.2.45", path=path).install()
     assert os.path.exists(driver_path)


### PR DESCRIPTION
### Problem: Could not install opera in [travis-ci build](https://travis-ci.org/SergeyPirogov/webdriver_manager/builds/656666726?utm_medium=notification&utm_source=github_status)

```
$ sudo apt install opera-stable

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
Reading package lists...
Building dependency tree...
Reading state information...
The following packages were automatically installed and are no longer required:
  libappindicator1 libdbusmenu-gtk4 libindicator7
Use 'sudo apt autoremove' to remove them.
The following additional packages will be installed:
  pepperflashplugin-nonfree
Suggested packages:
  chromium ttf-mscorefonts-installer ttf-dejavu ttf-xfree86-nonfree hal
The following NEW packages will be installed:
  opera-stable pepperflashplugin-nonfree
0 upgraded, 2 newly installed, 0 to remove and 302 not upgraded.
Need to get 67.1 MB of archives.
After this operation, 227 MB of additional disk space will be used.
Get:1 https://deb.opera.com/opera-stable stable/non-free amd64 opera-stable amd64 67.0.3575.31 [67.1 MB]
Get:2 http://archive.ubuntu.com/ubuntu trusty-updates/multiverse amd64 pepperflashplugin-nonfree amd64 1.3ubuntu1.1 [4,736 B]
Preconfiguring packages ...
Fetched 67.1 MB in 1s (34.1 MB/s)
dpkg-deb: error: archive '/var/cache/apt/archives/opera-stable_67.0.3575.31_amd64.deb' has premature member 'control.tar.xz' before 'control.tar.gz', giving up
dpkg: error processing archive /var/cache/apt/archives/opera-stable_67.0.3575.31_amd64.deb (--unpack):
 subprocess dpkg-deb --control returned error exit status 2
Selecting previously unselected package pepperflashplugin-nonfree.
(Reading database ... 93702 files and directories currently installed.)
Preparing to unpack .../pepperflashplugin-nonfree_1.3ubuntu1.1_amd64.deb ...
Unpacking pepperflashplugin-nonfree (1.3ubuntu1.1) ...
Errors were encountered while processing:
 /var/cache/apt/archives/opera-stable_67.0.3575.31_amd64.deb
E: Sub-process /usr/bin/dpkg returned an error code (1)
The command "sudo apt install opera-stable" failed and exited with 100 during .
Your build has been stopped.
```
### Reason
Travis-CI uses very old version ubuntu 14.04.5 from 2016 (latest trusty is 14.04.6 from 2019)
### Solution
Use `bionic` distributive for virtualization in travis-ci.