### PR TITLE
set required minimum python version to 3.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ ENV/
 .ropeproject
 .idea/
 .drivers/
+
+# VS code config
+.vscode

--- a/README.md
+++ b/README.md
@@ -1,34 +1,38 @@
-= Webdriver Manager for Python
+# Webdriver Manager for Python
 
-image:https://travis-ci.org/SergeyPirogov/webdriver_manager.svg?branch=master["Build Status", link="https://travis-ci.org/SergeyPirogov/webdriver_manager"]
-image:https://img.shields.io/pypi/v/webdriver_manager.svg["PyPI", link="https://pypi.org/project/webdriver-manager/"]
+![Build Status](https://travis-ci.org/SergeyPirogov/webdriver_manager.svg?branch=master)
+![PyPI](https://img.shields.io/pypi/v/webdriver_manager.svg)
 
 The main idea is to simplify management of binary drivers for different browsers.
 
 For now support:
 
 - ChromeDriver
+
 - GeckoDriver
+
 - IEDriver
+
 - OperaDriver
+
 - EdgeChromiumDriver
 
 Before:
 You should download binary chromedriver, unzip it somewhere in you PC and set path to this driver like this:
 
-```
+```python
 webdriver.Chrome('/home/user/drivers/chromedriver')
 
 ChromeDriverManager(path=custom_path).install()
 ```
 
-It's boring!!! Moreover every time the new version of driver released, you should go and repeat all steps again and again.
+It’s boring!!! Moreover every time the new version of driver released, you should go and repeat all steps again and again.
 
 With webdriver manager, you just need to do two simple steps:
 
 Install manager:
 
-```
+```bash
 pip install webdriver_manager
 ```
 
@@ -39,6 +43,7 @@ from webdriver_manager.chrome import ChromeDriverManager
 
 webdriver.Chrome(ChromeDriverManager().install())
 ```
+
 Use with FireFox:
 
 ```python
@@ -46,12 +51,14 @@ from webdriver_manager.firefox import GeckoDriverManager
 
 driver = webdriver.Firefox(executable_path=GeckoDriverManager().install())
 ```
-If you face error related to github credentials, you need to place github token: (*)
+
+If you face error related to github credentials, you need to place github token: (\*)
 
 ```python
 driver = webdriver.Firefox(executable_path=GeckoDriverManager().install())
 ```
-(*) access_token required to work with Github API more info https://help.github.com/articles/creating-an-access-token-for-command-line-use/.
+
+(\*) access_token required to work with Github API more info <https://help.github.com/articles/creating-an-access-token-for-command-line-use/>.
 
 Use with IE
 
@@ -59,7 +66,6 @@ Use with IE
 from webdriver_manager.microsoft import IEDriverManager
 
 driver = webdriver.Ie(IEDriverManager().install())
-
 ```
 
 Use with Opera
@@ -88,18 +94,16 @@ Use with Edge
 from webdriver_manager.microsoft import EdgeChromiumDriverManager
 
 driver = webdriver.Edge(EdgeChromiumDriverManager().install())
-
 ```
 
-== Configuration
+## Configuration
 
 There is also possibility to set same variables via ENV VARIABLES.
 
 Example:
 
-```
+```bash
 export GH_TOKEN = "asdasdasdasd"
 ```
 
 This will make your test automation more elegant and robust!
-

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ import setuptools
 
 setuptools.setup(
     name='webdriver_manager',
+    python_requires=">=3.6",
     packages=setuptools.find_packages(exclude=['tests']),
     include_package_data=True,
     version='2.4.0',
@@ -27,7 +28,9 @@ setuptools.setup(
         'License :: OSI Approved :: Apache Software License',
         'Intended Audience :: Information Technology',
         'Intended Audience :: Developers',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Software Development :: '
         'Libraries :: Python Modules',
         'Operating System :: Microsoft :: Windows',

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,15 @@
 
 import setuptools
 
+with open("README.md", encoding="utf-8") as readme_file:
+    readme = readme_file.read()
+
+
 setuptools.setup(
     name='webdriver_manager',
     python_requires=">=3.6",
+    long_description=readme,
+    long_description_content_type="text/markdown",
     packages=setuptools.find_packages(exclude=['tests']),
     include_package_data=True,
     version='2.4.0',


### PR DESCRIPTION
First of all thanks for this tool 😄 

Sadly, when I ran my test suite today, I saw that version `2.4.0` did deprecate python 3.5 and breaks it due to [this f-string](https://github.com/SergeyPirogov/webdriver_manager/blob/cf1e2f25064213165e97dbdc5b24063603eedffb/webdriver_manager/driver.py#L77).
The added kwarg to the setup, tells PyPi not to install the package on python versions lower than 3.6 and thus would fix future bad surprises.

P.S.: If you are willing to let me convert the readme from asciidoc to markdown, I could change the setup further, so the readme could be properly [rendered on PyPi](https://packaging.python.org/guides/making-a-pypi-friendly-readme/#creating-a-readme-file).