### PR TITLE
Remove redundant call to close() file

### DIFF
--- a/webdriver_manager/utils.py
+++ b/webdriver_manager/utils.py
@@ -51,7 +51,6 @@ def validate_response(resp):
 def write_file(content, path):
     with open(path, "wb") as code:
         code.write(content)
-        code.close()
     return path
 
 


### PR DESCRIPTION
No need to explicitly  call `close()` here.  Exiting the `with` block already closes the file.