### PR TITLE
Add scheduled test run to the test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: "Tests"
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 7 * * 1" # At 07:00 UTC on each Monday.
 
 jobs:
   test:


### PR DESCRIPTION
Since the download of the webdrivers and getting the latest versions, depends on url paths, which could be changed, IMHO it is a good idea to run the tests periodically to see if there are breaking changes.
If you want them to run on a different schedule, feel free to change it.