### PR TITLE
Add option to disable printing in log output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,20 @@ or via constructor:
 ChromeDriverManager("2.26", log_level=0).install()
 ```
 
+By default webdriver manager prints a blank space before its log output if logging is enabled. If you want to disable this, initialize `WDM_PRINT_FIRST_LINE` with `'False'` before your tests:
+
+```python
+import os
+
+os.environ['WDM_PRINT_FIRST_LINE'] = 'False'
+``` 
+
+or via constructor:
+
+```python
+ChromeDriverManager("2.26", print_first_line=False).install()
+```
+
 By default all driver binaries are saved to user.home/.wdm folder. You can override this setting and save binaries to project.root/.wdm.
 
 ```

--- a/tests/test_no_print_global_logs.py
+++ b/tests/test_no_print_global_logs.py
@@ -1,0 +1,17 @@
+import os
+
+import pytest
+
+from webdriver_manager.chrome import ChromeDriverManager
+
+
+@pytest.fixture
+def log():
+    os.environ['WDM_PRINT_FIRST_LINE'] = 'False'
+    yield
+    os.environ['WDM_PRINT_FIRST_LINE'] = 'True'
+
+
+def test_chrome_manager_with_specific_version(log):
+    bin = ChromeDriverManager("2.26").install()
+    assert os.path.exists(bin)

--- a/webdriver_manager/chrome.py
+++ b/webdriver_manager/chrome.py
@@ -17,8 +17,10 @@ class ChromeDriverManager(DriverManager):
                  latest_release_url="http://chromedriver.storage.googleapis.com/LATEST_RELEASE",
                  chrome_type=ChromeType.GOOGLE,
                  log_level=logging.INFO,
+                 print_first_line=None,
                  cache_valid_range=1):
-        super().__init__(path, log_level=log_level, cache_valid_range=cache_valid_range)
+        super().__init__(path, log_level=log_level, print_first_line=print_first_line,
+                         cache_valid_range=cache_valid_range)
 
         self.driver = ChromeDriver(name=name,
                                    version=version,

--- a/webdriver_manager/firefox.py
+++ b/webdriver_manager/firefox.py
@@ -14,8 +14,9 @@ class GeckoDriverManager(DriverManager):
                  latest_release_url="https://api.github.com/repos/mozilla/geckodriver/releases/latest",
                  mozila_release_tag="https://api.github.com/repos/mozilla/geckodriver/releases/tags/{0}",
                  log_level=logging.INFO,
+                 print_first_line=None,
                  cache_valid_range=1):
-        super(GeckoDriverManager, self).__init__(path, log_level, cache_valid_range)
+        super(GeckoDriverManager, self).__init__(path, log_level, print_first_line, cache_valid_range)
 
         self.driver = GeckoDriver(version=version,
                                   os_type=os_type,

--- a/webdriver_manager/logger.py
+++ b/webdriver_manager/logger.py
@@ -5,9 +5,10 @@ loggers = {}
 
 
 def log(text, level=logging.INFO, name="WDM", first_line=False):
-    if first_line:
-        print(" ")
     log_level = os.getenv('WDM_LOG_LEVEL')
+    print_first_line = os.getenv('WDM_PRINT_FIRST_LINE', default='true').lower() == 'true'
+    if first_line and print_first_line and log_level != '0':
+        print(" ")
     if log_level:
         level = int(log_level)
     if loggers.get(name):

--- a/webdriver_manager/manager.py
+++ b/webdriver_manager/manager.py
@@ -5,11 +5,14 @@ from webdriver_manager.utils import download_file
 
 
 class DriverManager(object):
-    def __init__(self, root_dir=None, log_level=None, cache_valid_range=1):
+    def __init__(self, root_dir=None, log_level=None, print_first_line=None, cache_valid_range=1):
         self.driver_cache = DriverCache(root_dir, cache_valid_range)
         global_log_level = os.getenv('WDM_LOG_LEVEL')
         if not global_log_level and log_level:
             os.environ['WDM_LOG_LEVEL'] = str(log_level)
+        global_print_first_line = os.getenv('WDM_PRINT_FIRST_LINE')
+        if not global_print_first_line and print_first_line:
+            os.environ['WDM_PRINT_FIRST_LINE'] = str(print_first_line)
 
     def install(self):
         raise NotImplementedError("Please Implement this method")

--- a/webdriver_manager/microsoft.py
+++ b/webdriver_manager/microsoft.py
@@ -14,8 +14,9 @@ class IEDriverManager(DriverManager):
                  url="http://selenium-release.storage.googleapis.com",
                  latest_release_url=None,
                  log_level=None,
+                 print_first_line=None,
                  cache_valid_range=1):
-        super().__init__(path, log_level, cache_valid_range)
+        super().__init__(path, log_level, print_first_line, cache_valid_range)
         self.driver = IEDriver(version=version,
                                os_type=os_type,
                                name=name,
@@ -35,8 +36,9 @@ class EdgeChromiumDriverManager(DriverManager):
                  latest_release_url="https://msedgedriver.azureedge.net/"
                                     "LATEST_RELEASE",
                  log_level=None,
+                 print_first_line=None,
                  cache_valid_range=1):
-        super().__init__(path, log_level, cache_valid_range)
+        super().__init__(path, log_level, print_first_line, cache_valid_range)
         self.driver = EdgeChromiumDriver(version=version,
                                          os_type=os_type,
                                          name=name,

--- a/webdriver_manager/opera.py
+++ b/webdriver_manager/opera.py
@@ -18,8 +18,9 @@ class OperaDriverManager(DriverManager):
                  opera_release_tag="https://api.github.com/repos/"
                  "operasoftware/operachromiumdriver/releases/tags/{0}",
                  log_level=logging.INFO,
+                 print_first_line=None,
                  cache_valid_range=1):
-        super().__init__(path, log_level, cache_valid_range)
+        super().__init__(path, log_level, print_first_line, cache_valid_range)
 
         self.driver = OperaDriver(name=name,
                                   version=version,


### PR DESCRIPTION
This pull request adds an option to disable printing while logging as discussed in #148. I've tried to keep the style identical to what is used to set the log level. I've also set it up to disable the print if the user has turned off logging as described in the documentation. 

Just a note: I have not changed this in this pull request, but the chrome and opera managers set the log level to info by default which will override the global setting. Not sure if this is intentional or not. 