### PR TITLE
Restructure logger.py to separate init and usage

### DIFF
--- a/webdriver_manager/logger.py
+++ b/webdriver_manager/logger.py
@@ -3,14 +3,12 @@ import os
 
 loggers = {}
 
-
-def log(text, level=logging.INFO, name="WDM", first_line=False, formatter='[%(name)s] - %(message)s'):
+def _init_logger(level=logging.INFO, name="WDM", first_line=False, formatter='[%(name)s] - %(message)s'):
+    """Initialize the logger."""
     log_level = os.getenv('WDM_LOG_LEVEL')
     if log_level:
         level = int(log_level)
-    if loggers.get(name):
-        loggers.get(name).info(text)
-    else:
+    if not loggers.get(name):
         _logger = logging.getLogger(name)
 
         handler = logging.StreamHandler()
@@ -19,4 +17,10 @@ def log(text, level=logging.INFO, name="WDM", first_line=False, formatter='[%(na
         _logger.addHandler(handler)
         _logger.setLevel(level)
         loggers[name] = _logger
-        _logger.info(text)
+
+def log(text, level=logging.INFO, name="WDM", first_line=False, formatter='[%(name)s] - %(message)s'):
+    """Emitting the log message."""
+    _init_logger(level, name, first_line, formatter)
+    loggers.get(name).info(text)
+    
+_init_logger()


### PR DESCRIPTION
The current structure of the module is not standard and makes it harder to control the logger. This version helps controlling the logger which is created on import.
The current code is flexible by giving the ability to change name, formatting and level, every time the log (emitter) function is called.
The proposed change is still not following logging standards, but this version should be backward compatible avoiding regressions.
Please note that the level argument of the log function does not specify the log level of the message emitted but the log level of the logger, this must be confusing and error-prone