### PR TITLE
🩹 Fix MacOS CI chrome and opera installation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Macos dependencies
         if: startsWith(runner.os, 'macOS')
         run: |
-          brew cask install chromium opera
+          brew install --cask chromium opera
 
       - name: Install Python dependencies
         run: |


### PR DESCRIPTION
Looks like `homebrew` on MacOS changed the command to install a cask package from `brew cask install <package>` to 
`brew install --cask <package>`.
This fixes the error when installing `chromium` and `opera`. 
But the tests still fail due to the M1 CPU issue (#174), which hopefully will be fixed by #178.