### PR TITLE
add log to firefox-wdm like in chrome-wdm

### DIFF
--- a/webdriver_manager/driver.py
+++ b/webdriver_manager/driver.py
@@ -11,7 +11,9 @@ from webdriver_manager.utils import (
     chrome_version,
     ChromeType,
     os_name,
-    OSType)
+    OSType,
+    firefox_version,
+)
 
 
 class Driver(object):
@@ -78,13 +80,14 @@ class GeckoDriver(Driver):
         self._mozila_release_tag = mozila_release_tag
         self._os_token = os.getenv("GH_TOKEN", None)
         self.auth_header = None
-        self.browser_version = ""
+        self.browser_version = firefox_version()
         if self._os_token:
             log("GH_TOKEN will be used to perform requests", first_line=True)
             self.auth_header = {'Authorization': f'token {self._os_token}'}
 
     def get_latest_release_version(self):
         # type: () -> str
+        log(f"Get LATEST driver version for {self.browser_version}")
         resp = requests.get(url=self.latest_release_url,
                             headers=self.auth_header)
         validate_response(resp)

--- a/webdriver_manager/firefox.py
+++ b/webdriver_manager/firefox.py
@@ -3,6 +3,7 @@ import logging
 from webdriver_manager import utils
 from webdriver_manager.driver import GeckoDriver
 from webdriver_manager.manager import DriverManager
+from webdriver_manager.logger import log
 
 
 class GeckoDriverManager(DriverManager):
@@ -26,4 +27,5 @@ class GeckoDriverManager(DriverManager):
                                   mozila_release_tag=mozila_release_tag)
 
     def install(self):
+        log(f"Current firefox version is {self.driver.browser_version}", first_line=True)
         return self._get_driver_path(self.driver)

--- a/webdriver_manager/utils.py
+++ b/webdriver_manager/utils.py
@@ -145,3 +145,22 @@ def chrome_version(browser_type=ChromeType.GOOGLE):
         raise ValueError(f'Could not get version for Chrome with this command: {cmd}')
     current_version = version.group(0)
     return current_version
+
+
+def firefox_version():
+    pattern = r'\d+.*'
+    cmd_mapping = {
+        OSType.LINUX: 'firefox --version',
+        OSType.MAC: r'/Applications/Firefox.app/Contents/MacOS/firefox --version',
+        OSType.WIN: r"(Get-Item (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\firefox.exe').'(Default)').VersionInfo.ProductVersion",
+    }
+    cmd = cmd_mapping[os_name()]
+    version = None
+    with os.popen(cmd) as stream:
+        stdout = stream.read()
+        version = re.search(pattern, stdout)
+
+    if not version:
+        raise ValueError(f'Could not get version for Chrome with this command: {cmd}')
+    current_version = version.group(0)
+    return current_version


### PR DESCRIPTION
### What?
Add Firefox version output in logs.
### Why?
I have noticed that there is no version message in logs for Mozilla Firefox browser and decided to add it like for Chrome.
