### PR TITLE
Propagate log level when creating driver manager

### DIFF
--- a/webdriver_manager/manager.py
+++ b/webdriver_manager/manager.py
@@ -9,7 +9,7 @@ class DriverManager(object):
     def __init__(self, root_dir=None, log_level=None, print_first_line=None, cache_valid_range=1):
         self.driver_cache = DriverCache(root_dir, cache_valid_range)
         if os.environ.get('WDM_PRINT_FIRST_LINE', str(print_first_line)) == 'True':
-            log("\n", formatter='%(message)s')
+            log("\n", formatter='%(message)s', level=log_level)
         log("====== WebDriver manager ======", level=log_level)
 
     def install(self):


### PR DESCRIPTION
Otherwise first line is logged no matter what `log_level` is set during creation of driver manager.

Similar to https://github.com/SergeyPirogov/webdriver_manager/pull/172