### PR TITLE
Fix incorrect version string iedriverserver

### DIFF
--- a/webdriver_manager/driver.py
+++ b/webdriver_manager/driver.py
@@ -157,8 +157,10 @@ class IEDriver(Driver):
             if self.get_name() in key and self._os_type in key:
                 last_modified = child.find(xmlns + 'LastModified').text
                 values[last_modified] = key
-
-        latest_key = values[max(values)]
+        
+        latest_key = values.pop(max(values))
+        while re.match(r".*_{os}_\.(.*)\.zip".format(os=self.get_os_type()), latest_key):
+            latest_key = values.pop(max(values))
         # 2.39/IEDriverServer_Win32_2.39.0.zip
         m = re.match(r".*_{os}_(.*)\.zip".format(os=self.get_os_type()),
                      latest_key)

--- a/webdriver_manager/driver.py
+++ b/webdriver_manager/driver.py
@@ -157,9 +157,11 @@ class IEDriver(Driver):
             if self.get_name() in key and self._os_type in key:
                 last_modified = child.find(xmlns + 'LastModified').text
                 values[last_modified] = key
-        
         latest_key = values.pop(max(values))
-        while re.match(r".*_{os}_\.(.*)\.zip".format(os=self.get_os_type()), latest_key):
+        while re.match(
+                r".*_{os}_\.(.*)\.zip".format(os=self.get_os_type()),
+                latest_key
+        ):
             latest_key = values.pop(max(values))
         # 2.39/IEDriverServer_Win32_2.39.0.zip
         m = re.match(r".*_{os}_(.*)\.zip".format(os=self.get_os_type()),


### PR DESCRIPTION
Fixes #216 

Checks for latest version strings but discards those that has a period after ostype_ and major version digit.
The below string even if latest will be skipped for the next most recently updated
`<Key>3.150/IEDriverServer_Win32_.3.150.2.zip</Key>`
.