### PR TITLE
Allows parametrizing requests' session

### DIFF
--- a/tests/test_chrome_driver.py
+++ b/tests/test_chrome_driver.py
@@ -24,13 +24,17 @@ def test_chrome_manager_with_wrong_version():
         ChromeDriverManager("0.2").install()
     assert "There is no such driver by url" in ex.value.args[0]
 
-
 def test_chrome_manager_with_selenium():
     driver_path = ChromeDriverManager().install()
     driver = webdriver.Chrome(driver_path)
     driver.get("http://automation-remarks.com")
     driver.close()
 
+def test_chrome_manager_without_verifying_with_selenium():
+    driver_path = ChromeDriverManager().dontVerifySsl().install()
+    driver = webdriver.Chrome(driver_path)
+    driver.get("http://automation-remarks.com")
+    driver.close()
 
 def test_chrome_manager_cached_driver_with_selenium():
     custom_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "custom")

--- a/webdriver_manager/driver.py
+++ b/webdriver_manager/driver.py
@@ -1,8 +1,8 @@
 import os
 import re
 from xml.etree import ElementTree
+from webdriver_manager.utils import session
 
-import requests
 import platform
 
 from webdriver_manager.logger import log
@@ -63,7 +63,7 @@ class ChromeDriver(Driver):
 
     def get_latest_release_version(self):
         log(f"Get LATEST driver version for {self.browser_version}")
-        resp = requests.get(f"{self._latest_release_url}_{self.browser_version}")
+        resp = session().get(f"{self._latest_release_url}_{self.browser_version}")
         validate_response(resp)
         return resp.text.rstrip()
 
@@ -88,7 +88,7 @@ class GeckoDriver(Driver):
     def get_latest_release_version(self):
         # type: () -> str
         log(f"Get LATEST driver version for {self.browser_version}")
-        resp = requests.get(url=self.latest_release_url,
+        resp = session().get(url=self.latest_release_url,
                             headers=self.auth_header)
         validate_response(resp)
         return resp.json()["tag_name"]
@@ -96,7 +96,7 @@ class GeckoDriver(Driver):
     def get_url(self):
         # https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-linux64.tar.gz
         log(f"Getting latest mozilla release info for {self.get_version()}")
-        resp = requests.get(url=self.tagged_release_url(self.get_version()),
+        resp = session().get(url=self.tagged_release_url(self.get_version()),
                             headers=self.auth_header)
         validate_response(resp)
         assets = resp.json()["assets"]
@@ -145,7 +145,7 @@ class IEDriver(Driver):
         data.sort()
 
     def get_latest_release_version(self):
-        resp = requests.get(self._url)
+        resp = session().get(self._url)
         root = ElementTree.fromstring(resp.text)
 
         values = {}
@@ -201,12 +201,12 @@ class OperaDriver(Driver):
         self.auth_header = None
         self.browser_version = ""
         if self._os_token:
-            log("GH_TOKEN will be used to perform requests")
+            log("GH_TOKEN will be used to perform request")
             self.auth_header = {'Authorization': f'token {self._os_token}'}
 
     def get_latest_release_version(self):
         # type: () -> str
-        resp = requests.get(self.latest_release_url, headers=self.auth_header)
+        resp = session().get(self.latest_release_url, headers=self.auth_header)
         validate_response(resp)
         return resp.json()["tag_name"]
 
@@ -215,7 +215,7 @@ class OperaDriver(Driver):
         # https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.45/operadriver_linux64.zip
         version = self.get_version()
         log(f"Getting latest opera release info for {version}")
-        resp = requests.get(url=self.tagged_release_url(version),
+        resp = session().get(url=self.tagged_release_url(version),
                             headers=self.auth_header)
         validate_response(resp)
         assets = resp.json()["assets"]
@@ -245,6 +245,6 @@ class EdgeChromiumDriver(Driver):
         else:
             major_edge_version = chrome_version(ChromeType.MSEDGE).split(".")[0]
             latest_release_url = self._latest_release_url + '_' + major_edge_version
-        resp = requests.get(latest_release_url)
+        resp = session().get(latest_release_url)
         validate_response(resp)
         return resp.text.rstrip()

--- a/webdriver_manager/manager.py
+++ b/webdriver_manager/manager.py
@@ -2,8 +2,7 @@ import os
 
 from webdriver_manager.driver_cache import DriverCache
 from webdriver_manager.logger import log
-from webdriver_manager.utils import download_file
-
+from webdriver_manager.utils import download_file, session, new_session
 
 class DriverManager(object):
     def __init__(self, root_dir=None, log_level=None, print_first_line=None, cache_valid_range=1):
@@ -11,6 +10,11 @@ class DriverManager(object):
         if os.environ.get('WDM_PRINT_FIRST_LINE', str(print_first_line)) == 'True':
             log("\n", formatter='%(message)s', level=log_level)
         log("====== WebDriver manager ======", level=log_level)
+        new_session()
+
+    def dontVerifySsl(self):
+        session().verify = False
+        return self
 
     def install(self):
         raise NotImplementedError("Please Implement this method")

--- a/webdriver_manager/utils.py
+++ b/webdriver_manager/utils.py
@@ -10,6 +10,13 @@ import requests
 from webdriver_manager.archive import Archive
 from webdriver_manager.logger import log
 
+def new_session():
+    global _session
+    _session = requests.Session()
+
+def session():
+    return _session
+
 
 class File(object):
 
@@ -90,7 +97,7 @@ def write_file(content, path):
 
 def download_file(url: str) -> File:
     log(f"Trying to download new driver from {url}")
-    response = requests.get(url, stream=True)
+    response = session().get(url, stream=True)
     validate_response(response)
     return File(response)
 


### PR DESCRIPTION
This version handles all calls to requests to a function which returns session object customizable. In this case we can disable verify ssl. This could fix #219.

Usage:
```python
    driver_path = GeckoDriverManager().dontVerifySsl().install()
    ff = webdriver.Firefox(executable_path=driver_path)
    ff.get("http://automation-remarks.com")
    ff.quit()
```