### PR TITLE
Aligned logging usage to python logging best practices

### DIFF
--- a/webdriver_manager/chrome.py
+++ b/webdriver_manager/chrome.py
@@ -1,9 +1,8 @@
-import logging
 import os
 
 from webdriver_manager import utils
 from webdriver_manager.driver import ChromeDriver
-from webdriver_manager.logger import log
+from webdriver_manager.logger import logger
 from webdriver_manager.manager import DriverManager
 from webdriver_manager.utils import ChromeType
 
@@ -16,11 +15,12 @@ class ChromeDriverManager(DriverManager):
                  url="https://chromedriver.storage.googleapis.com",
                  latest_release_url="https://chromedriver.storage.googleapis.com/LATEST_RELEASE",
                  chrome_type=ChromeType.GOOGLE,
-                 log_level=logging.INFO,
+                 log_level=None,
                  print_first_line=True,
                  cache_valid_range=1):
-        super().__init__(path, log_level=log_level, print_first_line=print_first_line,
+        super().__init__(path, print_first_line=print_first_line,
                          cache_valid_range=cache_valid_range)
+        # Parameter log_level is no longer used, remains to avoid breaking external calls
 
         self.driver = ChromeDriver(name=name,
                                    version=version,
@@ -30,7 +30,7 @@ class ChromeDriverManager(DriverManager):
                                    chrome_type=chrome_type)
 
     def install(self):
-        log(f"Current {self.driver.chrome_type} version is {self.driver.browser_version}", first_line=True)
+        logger.info(f"Current {self.driver.chrome_type} version is {self.driver.browser_version}")
         driver_path = self._get_driver_path(self.driver)
 
         os.chmod(driver_path, 0o755)

--- a/webdriver_manager/driver.py
+++ b/webdriver_manager/driver.py
@@ -3,7 +3,7 @@ import platform
 
 import requests
 
-from webdriver_manager.logger import log
+from webdriver_manager.logger import logger
 from webdriver_manager.utils import (
     validate_response,
     chrome_version,
@@ -60,7 +60,7 @@ class ChromeDriver(Driver):
         return super().get_os_type()
 
     def get_latest_release_version(self):
-        log(f"Get LATEST driver version for {self.browser_version}")
+        logger.info(f"Get LATEST driver version for {self.browser_version}")
         resp = requests.get(f"{self._latest_release_url}_{self.browser_version}")
         validate_response(resp)
         return resp.text.rstrip()
@@ -92,10 +92,10 @@ class GeckoDriver(Driver):
             else None
         )
         if self._os_token:
-            log("GH_TOKEN will be used to perform requests", first_line=True)
+            logger.info("GH_TOKEN will be used to perform requests", first_line=True)
 
     def get_latest_release_version(self) -> str:
-        log(f"Get LATEST driver version for {self.browser_version}")
+        logger.info(f"Get LATEST driver version for {self.browser_version}")
         resp = requests.get(
             url=self.latest_release_url,
             headers=self.auth_header,
@@ -105,7 +105,7 @@ class GeckoDriver(Driver):
 
     def get_url(self):
         """Like https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-linux64.tar.gz"""
-        log(f"Getting latest mozilla release info for {self.get_version()}")
+        logger.info(f"Getting latest mozilla release info for {self.get_version()}")
         resp = requests.get(
             url=self.tagged_release_url(self.get_version()),
             headers=self.auth_header,
@@ -163,10 +163,10 @@ class IEDriver(Driver):
             else None
         )
         if self._os_token:
-            log("GH_TOKEN will be used to perform requests", first_line=True)
+            logger.info("GH_TOKEN will be used to perform requests", first_line=True)
 
     def get_latest_release_version(self) -> str:
-        log(f"Get LATEST driver version for {self.browser_version}")
+        logger.info(f"Get LATEST driver version for {self.browser_version}")
         resp = requests.get(
             url=self.latest_release_url,
             headers=self.auth_header,
@@ -176,7 +176,7 @@ class IEDriver(Driver):
 
     def get_url(self):
         """Like https://github.com/seleniumhq/selenium/releases/download/3.141.59/IEDriverServer_Win32_3.141.59.zip"""
-        log(f"Getting latest ie release info for {self.get_version()}")
+        logger.info(f"Getting latest ie release info for {self.get_version()}")
         resp = requests.get(
             url=self.tagged_release_url(self.get_version()),
             headers=self.auth_header,
@@ -225,7 +225,7 @@ class OperaDriver(Driver):
         self.auth_header = None
         self.browser_version = ""
         if self._os_token:
-            log("GH_TOKEN will be used to perform requests")
+            logger.info("GH_TOKEN will be used to perform requests")
             self.auth_header = {'Authorization': f'token {self._os_token}'}
 
     def get_latest_release_version(self):
@@ -238,7 +238,7 @@ class OperaDriver(Driver):
         # type: () -> str
         # https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.45/operadriver_linux64.zip
         version = self.get_version()
-        log(f"Getting latest opera release info for {version}")
+        logger.info(f"Getting latest opera release info for {version}")
         resp = requests.get(url=self.tagged_release_url(version),
                             headers=self.auth_header)
         validate_response(resp)

--- a/webdriver_manager/driver_cache.py
+++ b/webdriver_manager/driver_cache.py
@@ -3,7 +3,7 @@ import json
 import os
 import sys
 
-from webdriver_manager.logger import log
+from webdriver_manager.logger import logger
 from webdriver_manager.utils import get_date_diff, File, save_file
 
 
@@ -29,7 +29,7 @@ class DriverCache(object):
         binary = self.__get_binary(files, driver_name)
         binary_path = os.path.join(path, binary)
         self.__save_metadata(browser_version, driver_name, os_type, driver_version, binary_path)
-        log(f"Driver has been saved in cache [{path}]")
+        logger.info(f"Driver has been saved in cache [{path}]")
         return binary_path
 
     def __get_binary(self, files, driver_name):
@@ -67,7 +67,7 @@ class DriverCache(object):
 
         key = f"{os_type}_{driver_name}_{driver_version}_for_{browser_version}"
         if key not in metadata:
-            log(f"There is no [{os_type}] {driver_name} for browser {browser_version} in cache")
+            logger.info(f"There is no [{os_type}] {driver_name} for browser {browser_version} in cache")
             return None
 
         driver_info = metadata[key]
@@ -76,7 +76,7 @@ class DriverCache(object):
             return None
 
         path = driver_info['binary_path']
-        log(f"Driver [{path}] found in cache")
+        logger.info(f"Driver [{path}] found in cache")
         return path
 
     def __is_valid(self, driver_info):

--- a/webdriver_manager/firefox.py
+++ b/webdriver_manager/firefox.py
@@ -1,9 +1,7 @@
-import logging
-
 from webdriver_manager import utils
 from webdriver_manager.driver import GeckoDriver
 from webdriver_manager.manager import DriverManager
-from webdriver_manager.logger import log
+from webdriver_manager.logger import logger
 
 
 class GeckoDriverManager(DriverManager):
@@ -14,10 +12,11 @@ class GeckoDriverManager(DriverManager):
                  url="https://github.com/mozilla/geckodriver/releases/download",
                  latest_release_url="https://api.github.com/repos/mozilla/geckodriver/releases/latest",
                  mozila_release_tag="https://api.github.com/repos/mozilla/geckodriver/releases/tags/{0}",
-                 log_level=logging.INFO,
+                 log_level=None,
                  print_first_line=True,
                  cache_valid_range=1):
-        super(GeckoDriverManager, self).__init__(path, log_level, print_first_line, cache_valid_range)
+        super(GeckoDriverManager, self).__init__(path, print_first_line, cache_valid_range)
+        # Parameter log_level is no longer used, remains to avoid breaking external calls
 
         self.driver = GeckoDriver(version=version,
                                   os_type=os_type,
@@ -27,5 +26,5 @@ class GeckoDriverManager(DriverManager):
                                   mozila_release_tag=mozila_release_tag)
 
     def install(self):
-        log(f"Current firefox version is {self.driver.browser_version}", first_line=True)
+        logger.info(f"Current firefox version is {self.driver.browser_version}")
         return self._get_driver_path(self.driver)

--- a/webdriver_manager/logger.py
+++ b/webdriver_manager/logger.py
@@ -1,26 +1,13 @@
 import logging
 import os
 
-loggers = {}
+logger = logging.getLogger('WDM')
 
-def _init_logger(level=logging.INFO, name="WDM", first_line=False, formatter='[%(name)s] - %(message)s'):
+def _init_logger(level=logging.INFO):
     """Initialize the logger."""
     log_level = os.getenv('WDM_LOG_LEVEL')
     if log_level:
         level = int(log_level)
-    if not loggers.get(name):
-        _logger = logging.getLogger(name)
-
-        handler = logging.StreamHandler()
-        formatter = logging.Formatter(formatter)
-        handler.setFormatter(formatter)
-        _logger.addHandler(handler)
-        _logger.setLevel(level)
-        loggers[name] = _logger
-
-def log(text, level=logging.INFO, name="WDM", first_line=False, formatter='[%(name)s] - %(message)s'):
-    """Emitting the log message."""
-    _init_logger(level, name, first_line, formatter)
-    loggers.get(name).info(text)
+    logger.setLevel(level)
     
 _init_logger()

--- a/webdriver_manager/manager.py
+++ b/webdriver_manager/manager.py
@@ -1,16 +1,16 @@
 import os
 
 from webdriver_manager.driver_cache import DriverCache
-from webdriver_manager.logger import log
+from webdriver_manager.logger import logger
 from webdriver_manager.utils import download_file
 
 
 class DriverManager(object):
-    def __init__(self, root_dir=None, log_level=None, print_first_line=None, cache_valid_range=1):
+    def __init__(self, root_dir=None, print_first_line=None, cache_valid_range=1):
         self.driver_cache = DriverCache(root_dir, cache_valid_range)
         if os.environ.get('WDM_PRINT_FIRST_LINE', str(print_first_line)) == 'True':
-            log("\n", formatter='%(message)s', level=log_level)
-        log("====== WebDriver manager ======", level=log_level)
+            logger.info("\n")
+        logger.info("====== WebDriver manager ======")
 
     def install(self):
         raise NotImplementedError("Please Implement this method")

--- a/webdriver_manager/microsoft.py
+++ b/webdriver_manager/microsoft.py
@@ -18,7 +18,8 @@ class IEDriverManager(DriverManager):
         print_first_line=True,
         cache_valid_range=1,
     ):
-        super().__init__(path, log_level, print_first_line, cache_valid_range)
+        super().__init__(path, print_first_line, cache_valid_range)
+        # Parameter log_level is no longer used, remains to avoid breaking external calls
         self.driver = IEDriver(
             version=version,
             os_type=os_type,
@@ -45,7 +46,8 @@ class EdgeChromiumDriverManager(DriverManager):
         print_first_line=None,
         cache_valid_range=1,
     ):
-        super().__init__(path, log_level, print_first_line, cache_valid_range)
+        super().__init__(path, print_first_line, cache_valid_range)
+        # Parameter log_level is no longer used, remains to avoid breaking external calls
         self.driver = EdgeChromiumDriver(
             version=version,
             os_type=os_type,

--- a/webdriver_manager/opera.py
+++ b/webdriver_manager/opera.py
@@ -1,4 +1,3 @@
-import logging
 import os
 
 from webdriver_manager import utils
@@ -17,10 +16,11 @@ class OperaDriverManager(DriverManager):
                  "operasoftware/operachromiumdriver/releases/latest",
                  opera_release_tag="https://api.github.com/repos/"
                  "operasoftware/operachromiumdriver/releases/tags/{0}",
-                 log_level=logging.INFO,
+                 log_level=None,
                  print_first_line=True,
                  cache_valid_range=1):
-        super().__init__(path, log_level, print_first_line, cache_valid_range)
+        super().__init__(path, print_first_line, cache_valid_range)
+        # Parameter log_level is no longer used, remains to avoid breaking external calls
 
         self.driver = OperaDriver(name=name,
                                   version=version,

--- a/webdriver_manager/utils.py
+++ b/webdriver_manager/utils.py
@@ -8,7 +8,7 @@ import sys
 import requests
 
 from webdriver_manager.archive import Archive
-from webdriver_manager.logger import log
+from webdriver_manager.logger import logger
 
 
 class File(object):
@@ -89,7 +89,7 @@ def write_file(content, path):
 
 
 def download_file(url: str) -> File:
-    log(f"Trying to download new driver from {url}")
+    logger.info(f"Trying to download new driver from {url}")
     response = requests.get(url, stream=True)
     validate_response(response)
     return File(response)


### PR DESCRIPTION
Aligned logging usage to python logging best practices [1]

In detail:
- completely rewrote logger.py to only consider the WDM_LOG_LEVEL environment variable
- modified every call to the logging function to adapt to the new structure
- didn't change init methods to be backwards-compatible (log_level parameter is ignored) and added comments explaining it

Downsides:
- Lost the abilty to set a fixed formatter for our logs
- Lost the difference in logging levels between microsoft drivers and the others

But these downsides can be addressed by the module user, which is now able to properly control logs

[1] https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library