### PR TITLE
finding EdgeDriver version for MAC & LINUX depends on MSEdge browser version and OS type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,11 +26,22 @@ jobs:
       - name: Install browsers on Linux
         if: runner.os == 'Linux'
         run: |
+          sudo apt-get update
+          sudo apt-get install software-properties-common apt-transport-https wget
+
+          wget -q https://packages.microsoft.com/keys/microsoft.asc -O- | sudo apt-key add -
+          sudo add-apt-repository "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main"
+          sudo apt-get update && sudo apt install microsoft-edge-beta
+          microsoft-edge --version
+
           wget -qO- https://deb.opera.com/archive.key | sudo apt-key add -
           sudo add-apt-repository "deb [arch=i386,amd64] https://deb.opera.com/opera-stable/ stable non-free"
           sudo apt-get update
-          sudo apt-get -y --no-install-recommends install opera-stable chromium-browser
+          sudo apt-get -y --no-install-recommends install opera-stable
           opera --version
+
+          sudo apt-get install chromium-browser
+          chromium --version
 
       - name: Install browsers on Windows
         if: runner.os == 'Windows'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,30 @@
 # Changelog
 
 ## 3.5.1
-- Fix huge typo in IEDriver (appeared accidentally in 3.5.0 version)
-- Adopt finding latest IEDriverSever for irregular releases in selenium.
+### IEDriver
+- Fix: huge typo in IEDriver (appeared accidentally in 3.5.0 version)
+- Adopt finding latest IEDriverSever for irregular releases in selenium ([#247](https://github.com/SergeyPirogov/webdriver_manager/issues/247))
+### EdgeDriver
+- Feature: finding EdgeDriver version for MAC & LINUX depends on MSEdge browser version and OS type [#243](https://github.com/SergeyPirogov/webdriver_manager/issues/243), Fix for [#242](https://github.com/SergeyPirogov/webdriver_manager/issues/242)
+- Fix: Add rights to execute edgedriver binary on linux.
+- Test Coverage: More tests for EdgeDriver
 
+---
 ## 3.5.0
 ### Fixes
-- Fix: WinError6 while executing script, packed in .exe by pyinstaller (#198)
-- Fix: stdio problem when making exe using pyinstaller with noconsole flag (#198)
-- Fix: error with execution right on linux afer extraction from zip (#208)
-- Fix: In Manager.DriverManager constructor named argument log_level is never passed to log() (#172
-- Fix: first-line not hidden when logs disabled (#212)
+- Fix: WinError6 while executing script, packed in .exe by pyinstaller ([#198](https://github.com/SergeyPirogov/webdriver_manager/issues/198))
+- Fix: stdio problem when making exe using pyinstaller with noconsole flag ([#198](https://github.com/SergeyPirogov/webdriver_manager/issues/198))
+- Fix: error with execution right on linux afer extraction from zip ([#208](https://github.com/SergeyPirogov/webdriver_manager/issues/208))
+- Fix: In Manager.DriverManager constructor named argument log_level is never passed to log() (#[172](https://github.com/SergeyPirogov/webdriver_manager/issues/172))
+- Fix: first-line not hidden when logs disabled ([#212](https://github.com/SergeyPirogov/webdriver_manager/issues/212))
 
 ### Features
-- Download IEDriverServer from GitHub (#227)
+- Download IEDriverServer from GitHub ([#227](https://github.com/SergeyPirogov/webdriver_manager/issues/227))
 
 ### Other
-- webdriver_manager now tests on 3.6, **3.7, 3.8, 3.9, 3.10** (#235)
-- webdriver_manager now supports not only 3.6, 3.7, 3.8, but also **3.9, 3.10** (#235) (tbh always has been)
-- webdriver_manager now releases to pypi by clicking "Publish GitHub release" button (#238)
+- webdriver_manager now tests on 3.6, **3.7, 3.8, 3.9, 3.10** ([#235](https://github.com/SergeyPirogov/webdriver_manager/issues/235))
+- webdriver_manager now supports not only 3.6, 3.7, 3.8, but also **3.9, 3.10** ([#235](https://github.com/SergeyPirogov/webdriver_manager/issues/235)) (tbh always has been)
+- webdriver_manager now releases to pypi by clicking "Publish GitHub release" button ([#238](https://github.com/SergeyPirogov/webdriver_manager/issues/238))
 ---
 
 lots releases ago...

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-selenium==3.141.0
-pytest==6.2.5
-pytest-cov==3.0.0
-codecov==2.1.12
-bump2version==1.0.1
-requests==2.26.0

--- a/tests/test_edge_driver.py
+++ b/tests/test_edge_driver.py
@@ -1,56 +1,53 @@
 import os
+
 import pytest
 from selenium import webdriver
+
 from webdriver_manager.microsoft import EdgeChromiumDriverManager
-from webdriver_manager.utils import os_name, os_type
 
 
-# TODO: set 'if os_name() != 'linux':
-# when edge > 82 is installed on mac os worker
 def test_edge_manager_with_selenium():
-    if os_name() == 'win':
-        driver_path = EdgeChromiumDriverManager(os_type=os_type()).install()
-        driver = webdriver.Edge(executable_path=driver_path)
-        driver.get("http://automation-remarks.com")
-        driver.quit()
-    else:
-        driver_path = EdgeChromiumDriverManager(os_type="win32").install()
-        assert os.path.exists(driver_path)
+    driver_path = EdgeChromiumDriverManager().install()
+
+    driver = webdriver.Edge(executable_path=driver_path, capabilities={})
+
+    driver.get("http://automation-remarks.com")
+    driver.quit()
 
 
 def test_edge_manager_with_wrong_version():
     with pytest.raises(ValueError) as ex:
-        driver_path = EdgeChromiumDriverManager("0.2",
-                                                os_type='win64').install()
+        driver_path = EdgeChromiumDriverManager(
+            version="0.2",
+            os_type='win64',
+        ).install()
         driver = webdriver.Edge(executable_path=driver_path)
         driver.quit()
-    assert "There is no such driver by url "\
-        "https://msedgedriver.azureedge.net/0.2/edgedriver_win64.zip" in \
-           ex.value.args[0]
+
+    assert (
+        "There is no such driver by url "
+        "https://msedgedriver.azureedge.net/0.2/edgedriver_win64.zip"
+    ) in ex.value.args[0]
 
 
-# TODO: add "mac64" when https://msedgedriver.azureedge.net/LATEST_STABLE
-# return edgedriver > 82
-# see:
-# https://msedgewebdriverstorage.z22.web.core.windows.net/?prefix=82.0.418.0/
-@pytest.mark.parametrize('os_type', ['win32', 'win64'])
+@pytest.mark.parametrize('os_type', ['win32', 'win64', 'linux64', 'mac64'])
 def test_can_download_edge_driver(os_type):
     path = EdgeChromiumDriverManager(os_type=os_type).install()
     assert os.path.exists(path)
 
 
-# TODO: add "mac64" when https://msedgedriver.azureedge.net/LATEST_STABLE
-# return edgedriver > 82
-# see:
-# https://msedgewebdriverstorage.z22.web.core.windows.net/?prefix=82.0.418.0/
-@pytest.mark.parametrize('os_type', ['win32', 'win64'])
+@pytest.mark.parametrize('os_type', ['win32', 'win64', 'mac64', 'linux64'])
 def test_can_get_edge_driver_from_cache(os_type):
     EdgeChromiumDriverManager(os_type=os_type).install()
     driver_path = EdgeChromiumDriverManager(os_type=os_type).install()
     assert os.path.exists(driver_path)
 
 
-def test_edge_with_specific_version():
-    bin_path = EdgeChromiumDriverManager("77.0.189.3",
-                                         os_type='win64').install()
+@pytest.mark.parametrize('os_type', ['win32', 'win64', 'mac64', 'linux64'])
+@pytest.mark.parametrize('specific_version', ['86.0.600.0'])
+def test_edge_with_specific_version(os_type, specific_version):
+    bin_path = EdgeChromiumDriverManager(
+        version=specific_version,
+        os_type=os_type,
+    ).install()
     assert os.path.exists(bin_path)

--- a/webdriver_manager/microsoft.py
+++ b/webdriver_manager/microsoft.py
@@ -1,3 +1,5 @@
+import os
+
 from webdriver_manager import utils
 from webdriver_manager.driver import EdgeChromiumDriver
 from webdriver_manager.driver import IEDriver
@@ -55,4 +57,7 @@ class EdgeChromiumDriverManager(DriverManager):
         )
 
     def install(self):
-        return self._get_driver_path(self.driver)
+        driver_path = self._get_driver_path(self.driver)
+
+        os.chmod(driver_path, 0o755)
+        return driver_path

--- a/webdriver_manager/utils.py
+++ b/webdriver_manager/utils.py
@@ -126,7 +126,8 @@ def linux_browser_apps_to_cmd(*apps: str) -> str:
     return ' || '.join(list(map(lambda i: f'{i} --version{ignore_errors_cmd_part}', apps)))
 
 
-def chrome_version(browser_type=ChromeType.GOOGLE):
+def get_browser_version_from_os(browser_type=None):
+    """Return installed browser version."""
     pattern = r'\d+\.\d+\.\d+'
 
     cmd_mapping = {
@@ -141,6 +142,7 @@ def chrome_version(browser_type=ChromeType.GOOGLE):
             OSType.WIN: r'reg query "HKLM\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Google Chrome" /v version'
         },
         ChromeType.MSEDGE: {
+            OSType.LINUX: linux_browser_apps_to_cmd('microsoft-edge', 'microsoft-edge-stable', 'microsoft-edge-beta', 'microsoft-edge-dev'),
             OSType.MAC: r'/Applications/Microsoft\ Edge.app/Contents/MacOS/Microsoft\ Edge --version',
             OSType.WIN: r'reg query "HKEY_CURRENT_USER\SOFTWARE\Microsoft\Edge\BLBeacon" /v version',
         }


### PR DESCRIPTION
- Feature: finding EdgeDriver version for MAC & LINUX depends on MSEdge browser version and OS type (Closes #243, Closes #242)
- Fix: Add rights to execute edgedriver binary on linux.
- Test Coverage: More tests for EdgeDriver & testing on LINUX/MAC in CI.
- delete requirements.txt