### PR TITLE
Solve network problems by passing requests' session

### DIFF
--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -36,6 +36,7 @@ def test_can_download_chrome_driver(delete_drivers_dir, version):
     driver = ChromeDriver(name="chromedriver", version=version, os_type="win32",
                           url="http://chromedriver.storage.googleapis.com",
                           latest_release_url="http://chromedriver.storage.googleapis.com/LATEST_RELEASE",
+                          session=None,
                           chrome_type=ChromeType.GOOGLE)
 
     file = download_file(driver.get_url())

--- a/tests/test_env_variables.py
+++ b/tests/test_env_variables.py
@@ -16,4 +16,4 @@ from webdriver_manager.driver import Driver
 def test_driver_ssl_verify_env(verify_value, expected_ssl_verify):
     os.environ['WDM_SSL_VERIFY'] = verify_value
 
-    assert Driver('a', 'b', 'c', 'd', 'e').ssl_verify is expected_ssl_verify
+    assert Driver('a', 'b', 'c', 'd', 'e', 'f').ssl_verify is expected_ssl_verify

--- a/tests/test_env_variables.py
+++ b/tests/test_env_variables.py
@@ -16,4 +16,5 @@ from webdriver_manager.driver import Driver
 def test_driver_ssl_verify_env(verify_value, expected_ssl_verify):
     os.environ['WDM_SSL_VERIFY'] = verify_value
 
-    assert Driver('a', 'b', 'c', 'd', 'e', 'f').ssl_verify is expected_ssl_verify
+    assert Driver('a', 'b', 'c', 'd', 'e',
+                  'f').ssl_verify is expected_ssl_verify

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1,0 +1,24 @@
+import pytest
+import requests
+from webdriver_manager.chrome import ChromeDriverManager
+
+
+def test_use_proxy():
+    session = requests.Session()
+    session.proxies = {
+        "http": "http://127.0.0.1:1", # it's a error proxy
+        "https": "http://127.0.0.1:1",
+    }
+
+    with pytest.raises(requests.exceptions.ProxyError):
+        # If an exception occurs, the proxy settings take effect
+        ChromeDriverManager(session=session).install()
+
+
+def test_disable_ssl_verify():
+    session = requests.Session()
+    session.verify = False
+
+    ChromeDriverManager(session=session).install()
+
+    

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1,12 +1,13 @@
 import pytest
 import requests
+
 from webdriver_manager.chrome import ChromeDriverManager
 
 
 def test_use_proxy():
     session = requests.Session()
     session.proxies = {
-        "http": "http://127.0.0.1:1", # it's a error proxy
+        "http": "http://127.0.0.1:1",  # it's a error proxy
         "https": "http://127.0.0.1:1",
     }
 
@@ -20,5 +21,3 @@ def test_disable_ssl_verify():
     session.verify = False
 
     ChromeDriverManager(session=session).install()
-
-    

--- a/webdriver_manager/chrome.py
+++ b/webdriver_manager/chrome.py
@@ -17,16 +17,20 @@ class ChromeDriverManager(DriverManager):
                  chrome_type=ChromeType.GOOGLE,
                  log_level=logging.INFO,
                  print_first_line=True,
-                 cache_valid_range=1):
+                 cache_valid_range=1,
+                 session=None
+                 ):
         super().__init__(path, log_level=log_level, print_first_line=print_first_line,
-                         cache_valid_range=cache_valid_range)
+                         cache_valid_range=cache_valid_range, session=session)
 
         self.driver = ChromeDriver(name=name,
                                    version=version,
                                    os_type=os_type,
                                    url=url,
                                    latest_release_url=latest_release_url,
-                                   chrome_type=chrome_type)
+                                   chrome_type=chrome_type,
+                                   session=self.session
+                                   )
 
     def install(self):
         driver_path = self._get_driver_path(self.driver)

--- a/webdriver_manager/chrome.py
+++ b/webdriver_manager/chrome.py
@@ -20,7 +20,8 @@ class ChromeDriverManager(DriverManager):
                  cache_valid_range=1,
                  session=None
                  ):
-        super().__init__(path, log_level=log_level, print_first_line=print_first_line,
+        super().__init__(path, log_level=log_level,
+                         print_first_line=print_first_line,
                          cache_valid_range=cache_valid_range, session=session)
 
         self.driver = ChromeDriver(name=name,

--- a/webdriver_manager/driver.py
+++ b/webdriver_manager/driver.py
@@ -1,8 +1,6 @@
 import os
 import platform
 
-import requests
-
 from webdriver_manager.logger import log
 from webdriver_manager.utils import (
     validate_response,
@@ -50,7 +48,8 @@ class Driver(object):
 
 
 class ChromeDriver(Driver):
-    def __init__(self, name, version, os_type, url, latest_release_url, session,
+    def __init__(self, name, version, os_type, url, latest_release_url,
+                 session,
                  chrome_type=ChromeType.GOOGLE):
         super(ChromeDriver, self).__init__(name, version, os_type, url,
                                            latest_release_url, session)
@@ -81,14 +80,14 @@ class ChromeDriver(Driver):
 
 class GeckoDriver(Driver):
     def __init__(
-        self,
-        name,
-        version,
-        os_type,
-        url,
-        latest_release_url,
-        session,
-        mozila_release_tag,
+            self,
+            name,
+            version,
+            os_type,
+            url,
+            latest_release_url,
+            session,
+            mozila_release_tag,
     ):
         super(GeckoDriver, self).__init__(
             name,
@@ -155,14 +154,14 @@ class GeckoDriver(Driver):
 
 class IEDriver(Driver):
     def __init__(
-        self,
-        name,
-        version,
-        os_type,
-        url,
-        latest_release_url,
-        session,
-        ie_release_tag,
+            self,
+            name,
+            version,
+            os_type,
+            url,
+            latest_release_url,
+            session,
+            ie_release_tag,
     ):
         super(IEDriver, self).__init__(
             name,
@@ -296,13 +295,13 @@ class OperaDriver(Driver):
 
 class EdgeChromiumDriver(Driver):
     def __init__(
-        self,
-        name,
-        version,
-        os_type,
-        url,
-        latest_release_url,
-        session,
+            self,
+            name,
+            version,
+            os_type,
+            url,
+            latest_release_url,
+            session,
     ):
         super(EdgeChromiumDriver, self).__init__(
             name,
@@ -317,7 +316,8 @@ class EdgeChromiumDriver(Driver):
     def get_latest_release_version(self) -> str:
         self.browser_version = get_browser_version_from_os(ChromeType.MSEDGE)
         log(f"Get LATEST {self._name} version for {self.browser_version} Edge")
-        major_edge_version = self.browser_version.split(".")[0] if self.browser_version != 'UNKNOWN' else None
+        major_edge_version = self.browser_version.split(".")[
+            0] if self.browser_version != 'UNKNOWN' else None
         latest_release_url = (
             {
                 OSType.WIN in self.get_os_type(): f'{self._latest_release_url}_{major_edge_version}_WINDOWS',
@@ -325,7 +325,8 @@ class EdgeChromiumDriver(Driver):
                 OSType.LINUX in self.get_os_type(): f'{self._latest_release_url}_{major_edge_version}_LINUX',
             }[True]
             if self.browser_version != "UNKNOWN"
-            else self._latest_release_url.replace('LATEST_RELEASE', 'LATEST_STABLE')
+            else self._latest_release_url.replace('LATEST_RELEASE',
+                                                  'LATEST_STABLE')
         )
         resp = self.session.get(latest_release_url, verify=self.ssl_verify)
         validate_response(resp)

--- a/webdriver_manager/firefox.py
+++ b/webdriver_manager/firefox.py
@@ -18,7 +18,11 @@ class GeckoDriverManager(DriverManager):
                  cache_valid_range=1,
                  session=None,
                  ):
-        super(GeckoDriverManager, self).__init__(path, log_level, print_first_line, cache_valid_range, session=session)
+        super(GeckoDriverManager, self).__init__(path, log_level,
+                                                 print_first_line,
+                                                 cache_valid_range,
+                                                 session=session
+                                                 )
 
         self.driver = GeckoDriver(version=version,
                                   os_type=os_type,

--- a/webdriver_manager/firefox.py
+++ b/webdriver_manager/firefox.py
@@ -15,14 +15,17 @@ class GeckoDriverManager(DriverManager):
                  mozila_release_tag="https://api.github.com/repos/mozilla/geckodriver/releases/tags/{0}",
                  log_level=logging.INFO,
                  print_first_line=True,
-                 cache_valid_range=1):
-        super(GeckoDriverManager, self).__init__(path, log_level, print_first_line, cache_valid_range)
+                 cache_valid_range=1,
+                 session=None,
+                 ):
+        super(GeckoDriverManager, self).__init__(path, log_level, print_first_line, cache_valid_range, session=session)
 
         self.driver = GeckoDriver(version=version,
                                   os_type=os_type,
                                   name=name,
                                   url=url,
                                   latest_release_url=latest_release_url,
+                                  session=self.session,
                                   mozila_release_tag=mozila_release_tag)
 
     def install(self):

--- a/webdriver_manager/manager.py
+++ b/webdriver_manager/manager.py
@@ -1,13 +1,18 @@
 import os
 
+import requests
+
 from webdriver_manager.driver_cache import DriverCache
 from webdriver_manager.logger import log
 from webdriver_manager.utils import download_file
 
 
 class DriverManager(object):
-    def __init__(self, root_dir=None, log_level=None, print_first_line=None, cache_valid_range=1):
+    session: requests.Session = None
+
+    def __init__(self, root_dir=None, log_level=None, print_first_line=None, cache_valid_range=1, session=None):
         self.driver_cache = DriverCache(root_dir, cache_valid_range)
+        self.session= session or requests.Session()
         if os.environ.get('WDM_PRINT_FIRST_LINE', str(print_first_line)) == 'True':
             log("\n", formatter='%(message)s', level=log_level)
         log("====== WebDriver manager ======", level=log_level)
@@ -27,7 +32,7 @@ class DriverManager(object):
         if binary_path:
             return binary_path
 
-        file = download_file(driver.get_url(), driver.ssl_verify)
+        file = download_file(driver.get_url(), driver.ssl_verify, session=self.session)
         binary_path = self.driver_cache.save_file_to_cache(file, browser_version,
                                                            driver_name, os_type, driver_version)
         return binary_path

--- a/webdriver_manager/manager.py
+++ b/webdriver_manager/manager.py
@@ -10,10 +10,12 @@ from webdriver_manager.utils import download_file
 class DriverManager(object):
     session: requests.Session = None
 
-    def __init__(self, root_dir=None, log_level=None, print_first_line=None, cache_valid_range=1, session=None):
+    def __init__(self, root_dir=None, log_level=None, print_first_line=None,
+                 cache_valid_range=1, session=None):
         self.driver_cache = DriverCache(root_dir, cache_valid_range)
-        self.session= session or requests.Session()
-        if os.environ.get('WDM_PRINT_FIRST_LINE', str(print_first_line)) == 'True':
+        self.session = session or requests.Session()
+        if os.environ.get('WDM_PRINT_FIRST_LINE',
+                          str(print_first_line)) == 'True':
             log("\n", formatter='%(message)s', level=log_level)
         log("====== WebDriver manager ======", level=log_level)
 
@@ -27,12 +29,17 @@ class DriverManager(object):
         os_type = driver.get_os_type()
         driver_version = driver.get_version()
 
-        binary_path = self.driver_cache.find_driver(browser_version, driver_name, os_type,
+        binary_path = self.driver_cache.find_driver(browser_version,
+                                                    driver_name, os_type,
                                                     driver_version)
         if binary_path:
             return binary_path
 
-        file = download_file(driver.get_url(), driver.ssl_verify, session=self.session)
-        binary_path = self.driver_cache.save_file_to_cache(file, browser_version,
-                                                           driver_name, os_type, driver_version)
+        file = download_file(driver.get_url(), driver.ssl_verify,
+                             session=self.session)
+        binary_path = self.driver_cache.save_file_to_cache(file,
+                                                           browser_version,
+                                                           driver_name,
+                                                           os_type,
+                                                           driver_version)
         return binary_path

--- a/webdriver_manager/microsoft.py
+++ b/webdriver_manager/microsoft.py
@@ -19,8 +19,9 @@ class IEDriverManager(DriverManager):
         log_level=None,
         print_first_line=True,
         cache_valid_range=1,
+        session=None,
     ):
-        super().__init__(path, log_level, print_first_line, cache_valid_range)
+        super().__init__(path, log_level, print_first_line, cache_valid_range, session=session)
         self.driver = IEDriver(
             version=version,
             os_type=os_type,
@@ -28,6 +29,7 @@ class IEDriverManager(DriverManager):
             url=url,
             latest_release_url=latest_release_url,
             ie_release_tag=ie_release_tag,
+            session=self.session
         )
 
     def install(self):
@@ -46,14 +48,16 @@ class EdgeChromiumDriverManager(DriverManager):
         log_level=None,
         print_first_line=None,
         cache_valid_range=1,
+        session=None,
     ):
-        super().__init__(path, log_level, print_first_line, cache_valid_range)
+        super().__init__(path, log_level, print_first_line, cache_valid_range, session=session)
         self.driver = EdgeChromiumDriver(
             version=version,
             os_type=os_type,
             name=name,
             url=url,
             latest_release_url=latest_release_url,
+            session=self.session
         )
 
     def install(self):

--- a/webdriver_manager/microsoft.py
+++ b/webdriver_manager/microsoft.py
@@ -8,20 +8,21 @@ from webdriver_manager.manager import DriverManager
 
 class IEDriverManager(DriverManager):
     def __init__(
-        self,
-        version="latest",
-        os_type=utils.os_type(),
-        path=None,
-        name="IEDriverServer",
-        url="https://github.com/seleniumhq/selenium/releases/download",
-        latest_release_url="https://api.github.com/repos/seleniumhq/selenium/releases",
-        ie_release_tag="https://api.github.com/repos/seleniumhq/selenium/releases/tags/selenium-{0}",
-        log_level=None,
-        print_first_line=True,
-        cache_valid_range=1,
-        session=None,
+            self,
+            version="latest",
+            os_type=utils.os_type(),
+            path=None,
+            name="IEDriverServer",
+            url="https://github.com/seleniumhq/selenium/releases/download",
+            latest_release_url="https://api.github.com/repos/seleniumhq/selenium/releases",
+            ie_release_tag="https://api.github.com/repos/seleniumhq/selenium/releases/tags/selenium-{0}",
+            log_level=None,
+            print_first_line=True,
+            cache_valid_range=1,
+            session=None,
     ):
-        super().__init__(path, log_level, print_first_line, cache_valid_range, session=session)
+        super().__init__(path, log_level, print_first_line, cache_valid_range,
+                         session=session)
         self.driver = IEDriver(
             version=version,
             os_type=os_type,
@@ -38,19 +39,20 @@ class IEDriverManager(DriverManager):
 
 class EdgeChromiumDriverManager(DriverManager):
     def __init__(
-        self,
-        version="latest",
-        os_type=utils.os_type(),
-        path=None,
-        name="edgedriver",
-        url="https://msedgedriver.azureedge.net",
-        latest_release_url="https://msedgedriver.azureedge.net/LATEST_RELEASE",
-        log_level=None,
-        print_first_line=None,
-        cache_valid_range=1,
-        session=None,
+            self,
+            version="latest",
+            os_type=utils.os_type(),
+            path=None,
+            name="edgedriver",
+            url="https://msedgedriver.azureedge.net",
+            latest_release_url="https://msedgedriver.azureedge.net/LATEST_RELEASE",
+            log_level=None,
+            print_first_line=None,
+            cache_valid_range=1,
+            session=None,
     ):
-        super().__init__(path, log_level, print_first_line, cache_valid_range, session=session)
+        super().__init__(path, log_level, print_first_line, cache_valid_range,
+                         session=session)
         self.driver = EdgeChromiumDriver(
             version=version,
             os_type=os_type,

--- a/webdriver_manager/opera.py
+++ b/webdriver_manager/opera.py
@@ -19,14 +19,17 @@ class OperaDriverManager(DriverManager):
                  "operasoftware/operachromiumdriver/releases/tags/{0}",
                  log_level=logging.INFO,
                  print_first_line=True,
-                 cache_valid_range=1):
-        super().__init__(path, log_level, print_first_line, cache_valid_range)
+                 cache_valid_range=1,
+                 session=None,
+                 ):
+        super().__init__(path, log_level, print_first_line, cache_valid_range, session=session)
 
         self.driver = OperaDriver(name=name,
                                   version=version,
                                   os_type=os_type,
                                   url=url,
                                   latest_release_url=latest_release_url,
+                                  session=self.session,
                                   opera_release_tag=opera_release_tag)
 
     def install(self):

--- a/webdriver_manager/opera.py
+++ b/webdriver_manager/opera.py
@@ -12,17 +12,18 @@ class OperaDriverManager(DriverManager):
                  path=None,
                  name="operadriver",
                  url="https://github.com/operasoftware/operachromiumdriver/"
-                 "releases/",
+                     "releases/",
                  latest_release_url="https://api.github.com/repos/"
-                 "operasoftware/operachromiumdriver/releases/latest",
+                                    "operasoftware/operachromiumdriver/releases/latest",
                  opera_release_tag="https://api.github.com/repos/"
-                 "operasoftware/operachromiumdriver/releases/tags/{0}",
+                                   "operasoftware/operachromiumdriver/releases/tags/{0}",
                  log_level=logging.INFO,
                  print_first_line=True,
                  cache_valid_range=1,
                  session=None,
                  ):
-        super().__init__(path, log_level, print_first_line, cache_valid_range, session=session)
+        super().__init__(path, log_level, print_first_line, cache_valid_range,
+                         session=session)
 
         self.driver = OperaDriver(name=name,
                                   version=version,

--- a/webdriver_manager/utils.py
+++ b/webdriver_manager/utils.py
@@ -21,7 +21,8 @@ class File(object):
     @property
     def filename(self) -> str:
         try:
-            filename = re.findall("filename=(.+)", self.__stream.headers["content-disposition"])[0]
+            filename = re.findall("filename=(.+)", self.__stream.headers[
+                "content-disposition"])[0]
         except KeyError:
             filename = f"{self.__temp_name}.zip"
         except IndexError:
@@ -92,7 +93,8 @@ def write_file(content, path):
     return path
 
 
-def download_file(url: str, ssl_verify=True, session: requests.Session= None) -> File:
+def download_file(url: str, ssl_verify=True,
+                  session: requests.Session = None) -> File:
     log(f"Trying to download new driver from {url}")
     if session is None:
         session = requests.Session()
@@ -103,14 +105,16 @@ def download_file(url: str, ssl_verify=True, session: requests.Session= None) ->
 
 def get_date_diff(date1, date2, date_format):
     a = datetime.datetime.strptime(date1, date_format)
-    b = datetime.datetime.strptime(str(date2.strftime(date_format)), date_format)
+    b = datetime.datetime.strptime(str(date2.strftime(date_format)),
+                                   date_format)
 
     return (b - a).days
 
 
 def get_filename_from_response(response, name):
     try:
-        filename = re.findall("filename=(.+)", response.headers["content-disposition"])[0]
+        filename = \
+        re.findall("filename=(.+)", response.headers["content-disposition"])[0]
     except KeyError:
         filename = "{}.zip".format(name)
     except IndexError:
@@ -128,8 +132,10 @@ def linux_browser_apps_to_cmd(*apps: str) -> str:
     Result command example:
         chromium --version || chromium-browser --version
     """
-    ignore_errors_cmd_part = ' 2>/dev/null' if os.getenv('WDM_LOG_LEVEL') == '0' else ''
-    return ' || '.join(list(map(lambda i: f'{i} --version{ignore_errors_cmd_part}', apps)))
+    ignore_errors_cmd_part = ' 2>/dev/null' if os.getenv(
+        'WDM_LOG_LEVEL') == '0' else ''
+    return ' || '.join(
+        list(map(lambda i: f'{i} --version{ignore_errors_cmd_part}', apps)))
 
 
 def get_browser_version_from_os(browser_type=None):
@@ -138,17 +144,22 @@ def get_browser_version_from_os(browser_type=None):
 
     cmd_mapping = {
         ChromeType.GOOGLE: {
-            OSType.LINUX: linux_browser_apps_to_cmd('google-chrome', 'google-chrome-stable'),
+            OSType.LINUX: linux_browser_apps_to_cmd('google-chrome',
+                                                    'google-chrome-stable'),
             OSType.MAC: r'/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --version',
             OSType.WIN: r'reg query "HKEY_CURRENT_USER\Software\Google\Chrome\BLBeacon" /v version'
         },
         ChromeType.CHROMIUM: {
-            OSType.LINUX: linux_browser_apps_to_cmd('chromium', 'chromium-browser'),
+            OSType.LINUX: linux_browser_apps_to_cmd('chromium',
+                                                    'chromium-browser'),
             OSType.MAC: r'/Applications/Chromium.app/Contents/MacOS/Chromium --version',
             OSType.WIN: r'reg query "HKLM\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Google Chrome" /v version'
         },
         ChromeType.MSEDGE: {
-            OSType.LINUX: linux_browser_apps_to_cmd('microsoft-edge', 'microsoft-edge-stable', 'microsoft-edge-beta', 'microsoft-edge-dev'),
+            OSType.LINUX: linux_browser_apps_to_cmd('microsoft-edge',
+                                                    'microsoft-edge-stable',
+                                                    'microsoft-edge-beta',
+                                                    'microsoft-edge-dev'),
             OSType.MAC: r'/Applications/Microsoft\ Edge.app/Contents/MacOS/Microsoft\ Edge --version',
             OSType.WIN: r'reg query "HKEY_CURRENT_USER\SOFTWARE\Microsoft\Edge\BLBeacon" /v version',
         }

--- a/webdriver_manager/utils.py
+++ b/webdriver_manager/utils.py
@@ -92,9 +92,11 @@ def write_file(content, path):
     return path
 
 
-def download_file(url: str, ssl_verify=True) -> File:
+def download_file(url: str, ssl_verify=True, session: requests.Session= None) -> File:
     log(f"Trying to download new driver from {url}")
-    response = requests.get(url, stream=True, verify=ssl_verify)
+    if session is None:
+        session = requests.Session()
+    response = session.get(url, stream=True, verify=ssl_verify)
     validate_response(response)
     return File(response)
 


### PR DESCRIPTION
Hi, 
I am very happy to find such a good tool like WDM , and I am planning to promote it in our team.
Encountered a thorny problem in practice: 
- Only use proxy service to access the Internet and download the driver
- Turn off the proxy server to access the system under test

WDM uses requests to complete network communication, but it does not provide a way to make full use of requests, so we use monkey patch to temporarily solve the problem.

At the same time, we noticed that #225 and #211 have not been merged yet. We also share a plan, hoping to arouse discussion in order to better improve WDM 

This PR made the following changes:
1. DriverManager and Driver accept session parameters
2. Use session.get instead of requests.get to complete network communication in WDM 

example:

```python
session = requests.Session()
session.proxies = {                              # use proxy
     "http": "http://127.0.0.1:1080",
     "https": "http://127.0.0.1:1080",
}
session.verify = False                          # disable_ssl_verify


driver_path = ChromeDriverManager(session=session).install()
```

The obvious benefit is,
1. The network communication is completely controlled by requests, and the responsibilities are clear
2. TCP connection will be reused
3. We can make some request use proxy, and some request does not use proxy






