### PR TITLE
chmod geckodriver path & fix tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 ---
 ## 3.5.3 Determine browser versions on Windows
 ### Bugfixes
-- Fixed logger for EdgeChromiumDriverManager and IEDriverManager (Resolves [#269](https://github.com/SergeyPirogov/webdriver_manager/issues/269), [#272](https://github.com/SergeyPirogov/webdriver_manager/issues/272)).
+- Fixed logger for EdgeChromiumDriverManager and IEDriverManager ([#269](https://github.com/SergeyPirogov/webdriver_manager/issues/269), [#272](https://github.com/SergeyPirogov/webdriver_manager/issues/272)).
+- Fixed `JSONDecodeError` when raising `ValueError` message of failed request. ([#273](https://github.com/SergeyPirogov/webdriver_manager/issues/273)).
+- Fixed `geckodriver` permissions. When `webdriver.Firefox(GeckoDriverManager().install())` caused `os error 10061`.
 ### Features
-- Determine browsers versions on Windows 32/64 bit by many ways. MSEdge, Chrome, Chromium, Firefox. PowerShell required. (Resolves [#261](https://github.com/SergeyPirogov/webdriver_manager/issues/261), [#193](https://github.com/SergeyPirogov/webdriver_manager/issues/193), [#293](https://github.com/SergeyPirogov/webdriver_manager/issues/293)).
+- Determine browsers versions on Windows 32/64 bit by many ways. MSEdge, Chrome, Chromium, Firefox. PowerShell required. ([#261](https://github.com/SergeyPirogov/webdriver_manager/issues/261), [#193](https://github.com/SergeyPirogov/webdriver_manager/issues/193), [#293](https://github.com/SergeyPirogov/webdriver_manager/issues/293)).
 ---
 - ## 3.5.2
 ### Features

--- a/tests/test_edge_driver.py
+++ b/tests/test_edge_driver.py
@@ -28,11 +28,10 @@ def test_driver_with_ssl_verify_disabled_can_be_downloaded(ssl_verify_enable):
 
 def test_edge_manager_with_wrong_version():
     with pytest.raises(ValueError) as ex:
-        driver_path = EdgeChromiumDriverManager(
+        EdgeChromiumDriverManager(
             version="0.2",
             os_type='win64',
         ).install()
-        webdriver.Edge(executable_path=driver_path)
 
     assert (
                "There is no such driver by url "

--- a/tests/test_firefox_manager.py
+++ b/tests/test_firefox_manager.py
@@ -26,8 +26,7 @@ def test_driver_with_ssl_verify_disabled_can_be_downloaded(ssl_verify_enable):
 
 def test_gecko_manager_with_wrong_version():
     with pytest.raises(ValueError) as ex:
-        driver_path = GeckoDriverManager("0.2").install()
-        webdriver.Firefox(executable_path=driver_path)
+        GeckoDriverManager("0.2").install()
 
     assert "There is no such driver by url "\
         "https://api.github.com/repos/mozilla/geckodriver/releases/tags/0.2" \

--- a/tests/test_opera_manager.py
+++ b/tests/test_opera_manager.py
@@ -49,8 +49,7 @@ def test_operadriver_manager_with_selenium():
 
 def test_opera_driver_manager_with_wrong_version():
     with pytest.raises(ValueError) as ex:
-        driver_path = OperaDriverManager("0.2").install()
-        webdriver.Opera(executable_path=driver_path)
+        OperaDriverManager("0.2").install()
 
     assert "There is no such driver by url " \
            "https://api.github.com/repos/operasoftware/operachromiumdriver/" \

--- a/webdriver_manager/firefox.py
+++ b/webdriver_manager/firefox.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 from webdriver_manager import utils
 from webdriver_manager.driver import GeckoDriver
@@ -26,4 +27,7 @@ class GeckoDriverManager(DriverManager):
                                   mozila_release_tag=mozila_release_tag)
 
     def install(self):
-        return self._get_driver_path(self.driver)
+        driver_path = self._get_driver_path(self.driver)
+
+        os.chmod(driver_path, 0o755)
+        return driver_path


### PR DESCRIPTION
- Fix test in `test_utils.py`.
- Add one more test for `validate_response()` function.
- Fix geckodriver permissions and test_geckodriver_with_selenium.
- Remove unused actions from tests with `pytest.raises(exception)`
- update changelog with fixes.