### PR TITLE
gh #277 os.environ['WDM_LOG'] = '0' disables logs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,8 @@ jobs:
       matrix:
         python-version: ['3.6']
         selenium-version: ['3.141.0']
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ macos-latest, windows-latest ]
+        wdm-log: ['']
         include:
           - python-version: '3.7'
             selenium-version: '4.1.0'
@@ -45,9 +46,7 @@ jobs:
           - python-version: '3.10'
             selenium-version: '3.141.0'
             os: ubuntu-latest
-          - python-version: '3.10'
-            selenium-version: '4.1.0'
-            os: ubuntu-latest
+            wdm-log: '0'
 
     steps:
       - uses: actions/checkout@v2
@@ -106,6 +105,8 @@ jobs:
       - name: Run tests on Linux (with xvfb)
         if: runner.os == 'Linux'
         uses: GabrielBB/xvfb-action@v1.0
+        env:
+          WDM_LOG: ${{ matrix.wdm-log }}
         with:
           run: |
             pipenv run py.test -sv --cov-config .coveragerc --cov-report xml --cov-report term:skip-covered --cov=webdriver_manager --tb=short tests/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 - Add Brave support, look "Use with Brave" chapter in README.md ([#331](https://github.com/SergeyPirogov/webdriver_manager/issues/331))
 - Speed up webdriver-manager in `driver.Driver.get_version()` method.
+- Disable logs by `os.environ['WDM_LOG'] = '0'` (Resolves [#277](https://github.com/SergeyPirogov/webdriver_manager/issues/277))
 ### Fixes
 - Error in `webdriver.util` `get_browser_version_from_os` for 32 bit applications ([#315](https://github.com/SergeyPirogov/webdriver_manager/issues/315))
 - `EdgeChromiumDriverManager().install()` fails in 3.5.3 when no Edge found ([#312](https://github.com/SergeyPirogov/webdriver_manager/issues/312))

--- a/README.md
+++ b/README.md
@@ -201,6 +201,14 @@ import os
 os.environ['GH_TOKEN'] = "asdasdasdasd"
 ```
 
+### `WDM_LOG`
+Turn off webdriver-manager logs with `os.environ['WDM_LOG'] == '0'`
+```python
+import os
+
+os.environ['WDM_LOG'] = '0'
+```
+
 ### `WDM_LOG_LEVEL`
 To silent `webdriver_manager` logs and remove them from console, initialize env variable `WDM_LOG_LEVEL` with `'0'` value before your selenium tests:
 

--- a/webdriver_manager/logger.py
+++ b/webdriver_manager/logger.py
@@ -22,5 +22,6 @@ def _init_logger(level=logging.INFO, name="WDM", first_line=False, formatter='[%
 
 def log(text, level=logging.INFO, name="WDM", first_line=False, formatter='[%(name)s] - %(message)s'):
     """Emitting the log message."""
-    _init_logger(level, name, first_line, formatter)
-    loggers.get(name).info(text)
+    if os.getenv('WDM_LOG', None) != '0':
+        _init_logger(level, name, first_line, formatter)
+        loggers.get(name).info(text)


### PR DESCRIPTION
Closes #277 
### What
This patch disables webdriver-manager logs. Finally.
To disable logs use:
```python
import os
os.environ["WDM_LOG"] = "0"
```
before your tests.

P.S. logs are still enabled by default.

Cheers!

### Definition of done
- Result without logs (disabled by env `WDM_LOG = "0"` ): https://github.com/SergeyPirogov/webdriver_manager/runs/5491658499?check_suite_focus=true
<img width="919" alt="image" src="https://user-images.githubusercontent.com/17043964/157603823-b16abd84-02ec-437d-ab77-487c9e768262.png">

- Result with logs (which are still enabled by default): https://github.com/SergeyPirogov/webdriver_manager/runs/5491658459?check_suite_focus=true

<img width="927" alt="image" src="https://user-images.githubusercontent.com/17043964/157603948-e7151c27-e533-408d-875f-93b71ae5b929.png">
