### PR TITLE
Added Fallback to Cache + Timeout

### DIFF
--- a/webdriver_manager/driver.py
+++ b/webdriver_manager/driver.py
@@ -13,17 +13,13 @@ from webdriver_manager.utils import (
 
 
 class Driver(object):
-    def __init__(self, name,
-                 version,
-                 os_type,
-                 url,
-                 latest_release_url):
+    def __init__(self, name, version, os_type, url, latest_release_url):
         self._name = name
         self._url = url
         self._version = version
         self._os_type = os_type
         self._latest_release_url = latest_release_url
-        self.ssl_verify = False if os.getenv('WDM_SSL_VERIFY') == '0' else True
+        self.ssl_verify = False if os.getenv("WDM_SSL_VERIFY") == "0" else True
 
     def get_name(self):
         return self._name
@@ -34,24 +30,29 @@ class Driver(object):
     def get_url(self):
         return f"{self._url}/{self.get_version()}/{self.get_name()}_{self.get_os_type()}.zip"
 
-    def get_version(self):
-        self._version = (
-            self.get_latest_release_version()
-            if self._version == "latest"
-            else self._version
-        )
+    def get_version(self, **kwargs) -> str:
+        if self._version == "latest":
+            self._version = self.get_latest_release_version(**kwargs)
+
         return self._version
 
-    def get_latest_release_version(self):
-        # type: () -> str
+    def get_latest_release_version(self, **kwargs) -> str:
         raise NotImplementedError("Please implement this method")
 
 
 class ChromeDriver(Driver):
-    def __init__(self, name, version, os_type, url, latest_release_url,
-                 chrome_type=ChromeType.GOOGLE):
-        super(ChromeDriver, self).__init__(name, version, os_type, url,
-                                           latest_release_url)
+    def __init__(
+        self,
+        name,
+        version,
+        os_type,
+        url,
+        latest_release_url,
+        chrome_type=ChromeType.GOOGLE,
+    ):
+        super(ChromeDriver, self).__init__(
+            name, version, os_type, url, latest_release_url
+        )
         self.chrome_type = chrome_type
         self.browser_version = ""
 
@@ -59,20 +60,19 @@ class ChromeDriver(Driver):
         if "win" in super().get_os_type():
             return "win32"
         mac = f'{super().get_os_type()}{"_m1" if "mac" in super().get_os_type() and not platform.processor() == "i386" else ""}'
-        return mac if 'mac' in super().get_os_type() else super().get_os_type()
+        return mac if "mac" in super().get_os_type() else super().get_os_type()
 
-    def get_latest_release_version(self):
+    def get_latest_release_version(self, **kwargs):
         self.browser_version = get_browser_version_from_os(self.chrome_type)
-        log(f"Get LATEST {self._name} version for {self.browser_version} {self.chrome_type}")
+        log(
+            f"Get LATEST {self._name} version for {self.browser_version} {self.chrome_type}"
+        )
         latest_release_url = (
             f"{self._latest_release_url}_{self.browser_version}"
             if self.browser_version
             else self._latest_release_url
         )
-        resp = requests.get(
-            url=latest_release_url,
-            verify=self.ssl_verify
-        )
+        resp = requests.get(url=latest_release_url, verify=self.ssl_verify, **kwargs)
         validate_response(resp)
         self._version = resp.text.rstrip()
         return self._version
@@ -99,20 +99,19 @@ class GeckoDriver(Driver):
         self.browser_version = ""
         self._os_token = os.getenv("GH_TOKEN", None)
         self.auth_header = (
-            {'Authorization': f'token {self._os_token}'}
-            if self._os_token
-            else None
+            {"Authorization": f"token {self._os_token}"} if self._os_token else None
         )
         if self._os_token:
             log("GH_TOKEN will be used to perform requests", first_line=True)
 
-    def get_latest_release_version(self) -> str:
+    def get_latest_release_version(self, **kwargs) -> str:
         self.browser_version = get_browser_version_from_os("firefox")
         log(f"Get LATEST {self._name} version for {self.browser_version} firefox")
         resp = requests.get(
             url=self.latest_release_url,
             headers=self.auth_header,
             verify=self.ssl_verify,
+            **kwargs,
         )
         validate_response(resp)
         self._version = resp.json()["tag_name"]
@@ -130,14 +129,12 @@ class GeckoDriver(Driver):
         assets = resp.json()["assets"]
 
         name = f"{self.get_name()}-{self.get_version()}-{self.get_os_type()}."
-        output_dict = [
-            asset for asset in assets if asset['name'].startswith(name)
-        ]
-        return output_dict[0]['browser_download_url']
+        output_dict = [asset for asset in assets if asset["name"].startswith(name)]
+        return output_dict[0]["browser_download_url"]
 
     def get_os_type(self):
         mac = f'macos{"-aarch64" if platform.processor() != "i386" else ""}'
-        return mac if 'mac' in super().get_os_type() else super().get_os_type()
+        return mac if "mac" in super().get_os_type() else super().get_os_type()
 
     @property
     def latest_release_url(self):
@@ -171,29 +168,28 @@ class IEDriver(Driver):
         self.browser_version = ""
         self._os_token = os.getenv("GH_TOKEN", None)
         self.auth_header = (
-            {'Authorization': f'token {self._os_token}'}
-            if self._os_token
-            else None
+            {"Authorization": f"token {self._os_token}"} if self._os_token else None
         )
         if self._os_token:
             log("GH_TOKEN will be used to perform requests", first_line=True)
 
-    def get_latest_release_version(self) -> str:
+    def get_latest_release_version(self, **kwargs) -> str:
         log(f"Get LATEST driver version for {self.browser_version}")
         resp = requests.get(
             url=self.latest_release_url,
             headers=self.auth_header,
             verify=self.ssl_verify,
+            **kwargs,
         )
         validate_response(resp)
         releases = resp.json()
         release = next(
             release
             for release in releases
-            for asset in release['assets']
-            if asset['name'].startswith(self.get_name())
+            for asset in release["assets"]
+            if asset["name"].startswith(self.get_name())
         )
-        self._version = release['tag_name'].replace('selenium-', '')
+        self._version = release["tag_name"].replace("selenium-", "")
         return self._version
 
     def get_url(self):
@@ -208,10 +204,8 @@ class IEDriver(Driver):
         assets = resp.json()["assets"]
 
         name = f"{self.get_name()}_{self.os_type}_{self.get_version()}" + "."
-        output_dict = [
-            asset for asset in assets if asset['name'].startswith(name)
-        ]
-        return output_dict[0]['browser_download_url']
+        output_dict = [asset for asset in assets if asset["name"].startswith(name)]
+        return output_dict[0]["browser_download_url"]
 
     @property
     def latest_release_url(self):
@@ -222,9 +216,9 @@ class IEDriver(Driver):
         return self._ie_release_tag.format(version)
 
     def __get_divided_version(self, version):
-        divided_version = version.split('.')
+        divided_version = version.split(".")
         if len(divided_version) == 2:
-            return f'{version}.0'
+            return f"{version}.0"
         elif len(divided_version) == 3:
             return version
         else:
@@ -235,27 +229,26 @@ class IEDriver(Driver):
 
 
 class OperaDriver(Driver):
-    def __init__(self, name,
-                 version,
-                 os_type,
-                 url,
-                 latest_release_url,
-                 opera_release_tag):
-        super(OperaDriver, self).__init__(name, version, os_type, url,
-                                          latest_release_url)
+    def __init__(
+        self, name, version, os_type, url, latest_release_url, opera_release_tag
+    ):
+        super(OperaDriver, self).__init__(
+            name, version, os_type, url, latest_release_url
+        )
         self.opera_release_tag = opera_release_tag
         self._os_token = os.getenv("GH_TOKEN", None)
         self.auth_header = None
         self.browser_version = ""
         if self._os_token:
             log("GH_TOKEN will be used to perform requests")
-            self.auth_header = {'Authorization': f'token {self._os_token}'}
+            self.auth_header = {"Authorization": f"token {self._os_token}"}
 
-    def get_latest_release_version(self) -> str:
+    def get_latest_release_version(self, **kwargs) -> str:
         resp = requests.get(
             url=self.latest_release_url,
             headers=self.auth_header,
             verify=self.ssl_verify,
+            **kwargs,
         )
         validate_response(resp)
         self._version = resp.json()["tag_name"]
@@ -273,9 +266,8 @@ class OperaDriver(Driver):
         validate_response(resp)
         assets = resp.json()["assets"]
         name = "{0}_{1}".format(self.get_name(), self.get_os_type())
-        output_dict = [asset for asset in assets if
-                       asset['name'].startswith(name)]
-        return output_dict[0]['browser_download_url']
+        output_dict = [asset for asset in assets if asset["name"].startswith(name)]
+        return output_dict[0]["browser_download_url"]
 
     @property
     def latest_release_url(self):
@@ -305,26 +297,27 @@ class EdgeChromiumDriver(Driver):
 
     def get_stable_release_version(self):
         """Stable driver version when browser version was not determined."""
-        stable = self._latest_release_url.replace('LATEST_RELEASE', 'LATEST_STABLE')
+        stable = self._latest_release_url.replace("LATEST_RELEASE", "LATEST_STABLE")
         resp = requests.get(stable, verify=self.ssl_verify)
         validate_response(resp)
         return resp.text.rstrip()
 
-    def get_latest_release_version(self) -> str:
+    def get_latest_release_version(self, **kwargs) -> str:
         browser_version = get_browser_version_from_os(ChromeType.MSEDGE)
         self.browser_version = (
-            browser_version
-            if browser_version
-            else self.get_stable_release_version()
+            browser_version if browser_version else self.get_stable_release_version()
         )
         log(f"Get LATEST {self._name} version for {self.browser_version} Edge")
         major_edge_version = self.browser_version.split(".")[0]
         latest_release_url = {
-            OSType.WIN in self.get_os_type(): f'{self._latest_release_url}_{major_edge_version}_WINDOWS',
-            OSType.MAC in self.get_os_type(): f'{self._latest_release_url}_{major_edge_version}_MACOS',
-            OSType.LINUX in self.get_os_type(): f'{self._latest_release_url}_{major_edge_version}_LINUX',
+            OSType.WIN
+            in self.get_os_type(): f"{self._latest_release_url}_{major_edge_version}_WINDOWS",
+            OSType.MAC
+            in self.get_os_type(): f"{self._latest_release_url}_{major_edge_version}_MACOS",
+            OSType.LINUX
+            in self.get_os_type(): f"{self._latest_release_url}_{major_edge_version}_LINUX",
         }[True]
-        resp = requests.get(latest_release_url, verify=self.ssl_verify)
+        resp = requests.get(latest_release_url, verify=self.ssl_verify, **kwargs)
         validate_response(resp)
         self._version = resp.text.rstrip()
         return self._version

--- a/webdriver_manager/driver_cache.py
+++ b/webdriver_manager/driver_cache.py
@@ -5,14 +5,14 @@ import sys
 
 from webdriver_manager.logger import log
 from webdriver_manager.utils import get_date_diff, File, save_file
+from webdriver_manager.driver import Driver
 
 
 class DriverCache(object):
-
     def __init__(self, root_dir=None, valid_range=1):
         self._root_dir = root_dir
 
-        if self._root_dir is None and os.environ.get("WDM_LOCAL", '0') == '1':
+        if self._root_dir is None and os.environ.get("WDM_LOCAL", "0") == "1":
             self._root_dir = os.path.join(sys.path[0], ".wdm")
         if self._root_dir is None:
             self._root_dir = os.path.join(os.path.expanduser("~"), ".wdm")
@@ -28,12 +28,16 @@ class DriverCache(object):
         driver_version = driver.get_version()
         browser_version = driver.browser_version
 
-        path = os.path.join(self._drivers_directory, driver_name, os_type, driver_version)
+        path = os.path.join(
+            self._drivers_directory, driver_name, os_type, driver_version
+        )
         archive = save_file(file, path)
         files = archive.unpack(path)
         binary = self.__get_binary(files, driver_name)
         binary_path = os.path.join(path, binary)
-        self.__save_metadata(browser_version, driver_name, os_type, driver_version, binary_path)
+        self.__save_metadata(
+            browser_version, driver_name, os_type, driver_version, binary_path
+        )
         log(f"Driver has been saved in cache [{path}]")
         return binary_path
 
@@ -47,8 +51,15 @@ class DriverCache(object):
 
         raise Exception(f"Can't find binary for {driver_name} among {files}")
 
-    def __save_metadata(self, browser_version, driver_name, os_type, driver_version, binary_path,
-                        date=None):
+    def __save_metadata(
+        self,
+        browser_version,
+        driver_name,
+        os_type,
+        driver_version,
+        binary_path,
+        date=None,
+    ):
         if date is None:
             date = datetime.date.today()
 
@@ -59,31 +70,109 @@ class DriverCache(object):
         data = {
             key: {
                 "timestamp": date.strftime(self._date_format),
-                "binary_path": binary_path
+                "binary_path": binary_path,
             }
         }
 
         metadata.update(data)
-        with open(self._drivers_json_path, 'w+') as outfile:
+        with open(self._drivers_json_path, "w+") as outfile:
             json.dump(metadata, outfile, indent=4)
 
-    def find_driver(self, driver):
-        """Find driver by '{os_type}_{driver_name}_{driver_version}_{browser_version}'."""
+    def find_latest_driver_in_cache(self, driver: Driver) -> str:
+        """Find the latest cached driver for the current browser.
+
+        Args:
+            driver (Driver): The browser to find the latest driver for.
+
+        Returns:
+            str: The path to the latest driver.
+            None: If no driver is found.
+        """
+        driver_name = driver.get_name()
+        os_type = driver.get_os_type()
+        browser_version = driver.browser_version
+
+        metadata = self.get_metadata()
+
+        latest = None
+        for key, val in metadata.items():
+            if not key.startswith(f"{os_type}_{driver_name}"):
+                continue
+            if not key.endswith(f"_for_{browser_version}"):
+                continue
+
+            dates_diff = get_date_diff(
+                val["timestamp"], datetime.date.today(), self._date_format
+            )
+
+            if not latest or latest["age"] < dates_diff:
+                latest = {"age": dates_diff, "path": val["binary_path"]}
+
+        if not latest:
+            log(
+                f"There is no [{os_type}] {driver_name} for browser {browser_version} in cache"
+            )
+            return None
+
+        path = val["binary_path"]
+        log(f"Driver [{path}] found in cache")
+        return path
+
+    def find_driver(
+        self,
+        driver: Driver,
+        timeout: int = 5,
+        fallback_to_latest: bool = True,
+    ) -> str:
+        """Find driver by '{os_type}_{driver_name}_{driver_version}_{browser_version}'.
+
+        Args:
+            timeout (int): An amount in seconds to wait for a response in case the
+                latest version has to be queried online. This is passed directly to
+                the ``requests.get()`` call.
+
+            fallback_to_latest (bool): In case the ``driver.get_version()`` call fails
+                for any reason (such as a request for a latest version being blocked)
+                then this will search through all the cached webdrivers to find the
+                most recent one and returns it.
+
+        Returns:
+            str: The path to the webdriver file.
+            None: If the file could not be found
+        """
+
+        # Attempt to find the correct driver version
+        try:
+            driver_version = driver.get_version(timeout=5)
+        except Exception:
+            log("No version found for driver")
+            if fallback_to_latest:
+                return self.find_latest_driver_in_cache(driver)
+            else:
+                return None
+
         os_type = driver.get_os_type()
         driver_name = driver.get_name()
-        driver_version = driver.get_version()
         browser_version = driver.browser_version
 
         metadata = self.get_metadata()
 
         key = f"{os_type}_{driver_name}_{driver_version}_for_{browser_version}"
         if key not in metadata:
-            log(f"There is no [{os_type}] {driver_name} for browser {browser_version} in cache")
+            log(
+                f"There is no [{os_type}] {driver_name} for browser {browser_version} in cache"
+            )
             return None
 
-        path = os.path.join(self._drivers_directory, driver_name, os_type, driver_version)
-        driver_binary_name = 'msedgedriver' if driver_name == 'edgedriver' else driver_name
-        driver_binary_name = f'{driver_binary_name}.exe' if 'win' in os_type else driver_name
+        path = os.path.join(
+            self._drivers_directory, driver_name, os_type, driver_version
+        )
+        driver_binary_name = (
+            "msedgedriver" if driver_name == "edgedriver" else driver_name
+        )
+        driver_binary_name = (
+            f"{driver_binary_name}.exe" if "win" in os_type else driver_name
+        )
         binary_path = os.path.join(path, driver_binary_name)
         if not os.path.exists(binary_path):
             return None
@@ -93,18 +182,18 @@ class DriverCache(object):
         if not self.__is_valid(driver_info):
             return None
 
-        path = driver_info['binary_path']
+        path = driver_info["binary_path"]
         log(f"Driver [{path}] found in cache")
         return path
 
     def __is_valid(self, driver_info):
-        dates_diff = get_date_diff(driver_info['timestamp'],
-                                   datetime.date.today(),
-                                   self._date_format)
+        dates_diff = get_date_diff(
+            driver_info["timestamp"], datetime.date.today(), self._date_format
+        )
         return dates_diff < self.valid_range
 
     def get_metadata(self):
         if os.path.exists(self._drivers_json_path):
-            with open(self._drivers_json_path, 'r') as outfile:
+            with open(self._drivers_json_path, "r") as outfile:
                 return json.load(outfile)
         return {}


### PR DESCRIPTION
Referencing issue #365 

This pull adds the ability to fallback to the most recent driver in the cache in case a call to 'latest' fails. It also adds a timeout to the `requests.get()` call, and some extra commenting and documentation.

There's also a bunch of formatting, thanks to black kicking in as soon as I save. (sigh.)

No testing of any sort was done on this aside from the chrome driver. I'm just sharing what I used in case this is useful to you all.
