### PR TITLE
Fix looking for incorrect binary for edgedriver on Linux

### DIFF
--- a/webdriver_manager/core/driver_cache.py
+++ b/webdriver_manager/core/driver_cache.py
@@ -111,7 +111,7 @@ class DriverCache(object):
             "msedgedriver" if driver_name == "edgedriver" else driver_name
         )
         driver_binary_name = (
-            f"{driver_binary_name}.exe" if "win" in os_type else driver_name
+            f"{driver_binary_name}.exe" if "win" in os_type else driver_binary_name
         )
         binary_path = os.path.join(path, driver_binary_name)
         if not os.path.exists(binary_path):


### PR DESCRIPTION
Previous version would make the script look for the cached Edge driver in the wrong location, causing it to always think the driver is not cached (and therefore download a new, unnecessary copy of the driver). 

Fixes #387.