### PR TITLE
Remove stream handlers from logging

### DIFF
--- a/webdriver_manager/core/logger.py
+++ b/webdriver_manager/core/logger.py
@@ -5,11 +5,6 @@ from webdriver_manager.core.config import wdm_log_level
 __logger = logging.getLogger("WDM")
 
 __logger.setLevel(wdm_log_level())
-handler = logging.StreamHandler()
-formatter = logging.Formatter("[%(name)s] - %(message)s")
-handler.setFormatter(formatter)
-__logger.addHandler(handler)
-
 
 def log(text):
     """Emitting the log message."""


### PR DESCRIPTION
Dependency modules should never set up their own log handlers - let parent projects do this.