### PR TITLE
use `Optional[]` type hints

### DIFF
--- a/webdriver_manager/chrome.py
+++ b/webdriver_manager/chrome.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 from webdriver_manager.core.download_manager import DownloadManager
 from webdriver_manager.core.manager import DriverManager
@@ -9,15 +10,15 @@ from webdriver_manager.drivers.chrome import ChromeDriver
 class ChromeDriverManager(DriverManager):
     def __init__(
             self,
-            version: str = None,
-            os_type: str = None,
-            path: str = None,
+            version: Optional[str] = None,
+            os_type: Optional[str] = None,
+            path: Optional[str] = None,
             name: str = "chromedriver",
             url: str = "https://chromedriver.storage.googleapis.com",
             latest_release_url: str = "https://chromedriver.storage.googleapis.com/LATEST_RELEASE",
             chrome_type: str = ChromeType.GOOGLE,
             cache_valid_range: int = 1,
-            download_manager: DownloadManager = None,
+            download_manager: Optional[DownloadManager] = None,
     ):
         super().__init__(
             path,

--- a/webdriver_manager/firefox.py
+++ b/webdriver_manager/firefox.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 from webdriver_manager.core.download_manager import DownloadManager
 from webdriver_manager.core.manager import DriverManager
@@ -7,16 +8,16 @@ from webdriver_manager.drivers.firefox import GeckoDriver
 
 class GeckoDriverManager(DriverManager):
     def __init__(
-            self,
-            version: str = None,
-            os_type: str = None,
-            path: str = None,
-            name: str = "geckodriver",
-            url: str = "https://github.com/mozilla/geckodriver/releases/download",
-            latest_release_url: str = "https://api.github.com/repos/mozilla/geckodriver/releases/latest",
-            mozila_release_tag: str = "https://api.github.com/repos/mozilla/geckodriver/releases/tags/{0}",
-            cache_valid_range: int = 1,
-            download_manager: DownloadManager = None,
+        self,
+        version: Optional[str] = None,
+        os_type: Optional[str] = None,
+        path: Optional[str] = None,
+        name: str = "geckodriver",
+        url: str = "https://github.com/mozilla/geckodriver/releases/download",
+        latest_release_url: str = "https://api.github.com/repos/mozilla/geckodriver/releases/latest",
+        mozila_release_tag: str = "https://api.github.com/repos/mozilla/geckodriver/releases/tags/{0}",
+        cache_valid_range: int = 1,
+        download_manager: Optional[DownloadManager] = None,
     ):
         super(GeckoDriverManager, self).__init__(
             path, cache_valid_range, download_manager=download_manager

--- a/webdriver_manager/microsoft.py
+++ b/webdriver_manager/microsoft.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 from webdriver_manager.core import utils
 from webdriver_manager.core.download_manager import DownloadManager
@@ -9,16 +10,16 @@ from webdriver_manager.core.manager import DriverManager
 
 class IEDriverManager(DriverManager):
     def __init__(
-            self,
-            version: str = None,
-            os_type: str = None,
-            path: str = None,
-            name: str = "IEDriverServer",
-            url: str = "https://github.com/seleniumhq/selenium/releases/download",
-            latest_release_url: str = "https://api.github.com/repos/seleniumhq/selenium/releases",
-            ie_release_tag: str = "https://api.github.com/repos/seleniumhq/selenium/releases/tags/selenium-{0}",
-            cache_valid_range: int = 1,
-            download_manager: DownloadManager = None,
+        self,
+        version: Optional[str] = None,
+        os_type: Optional[str] = None,
+        path: Optional[str] = None,
+        name: str = "IEDriverServer",
+        url: str = "https://github.com/seleniumhq/selenium/releases/download",
+        latest_release_url: str = "https://api.github.com/repos/seleniumhq/selenium/releases",
+        ie_release_tag: str = "https://api.github.com/repos/seleniumhq/selenium/releases/tags/selenium-{0}",
+        cache_valid_range: int = 1,
+        download_manager: Optional[DownloadManager] = None,
     ):
         super().__init__(path, cache_valid_range, download_manager=download_manager)
         self.driver = IEDriver(
@@ -37,15 +38,15 @@ class IEDriverManager(DriverManager):
 
 class EdgeChromiumDriverManager(DriverManager):
     def __init__(
-            self,
-            version: str = None,
-            os_type: str = utils.os_type(),
-            path: str = None,
-            name: str = "edgedriver",
-            url: str = "https://msedgedriver.azureedge.net",
-            latest_release_url: str = "https://msedgedriver.azureedge.net/LATEST_RELEASE",
-            cache_valid_range: int = 1,
-            download_manager: DownloadManager = None,
+        self,
+        version: Optional[str] = None,
+        os_type: str = utils.os_type(),
+        path: Optional[str] = None,
+        name: str = "edgedriver",
+        url: str = "https://msedgedriver.azureedge.net",
+        latest_release_url: str = "https://msedgedriver.azureedge.net/LATEST_RELEASE",
+        cache_valid_range: int = 1,
+        download_manager: Optional[DownloadManager] = None,
     ):
         super().__init__(path, cache_valid_range, download_manager=download_manager)
         self.driver = EdgeChromiumDriver(

--- a/webdriver_manager/opera.py
+++ b/webdriver_manager/opera.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 from webdriver_manager.core.download_manager import DownloadManager
 from webdriver_manager.core.manager import DriverManager
@@ -7,19 +8,19 @@ from webdriver_manager.drivers.opera import OperaDriver
 
 class OperaDriverManager(DriverManager):
     def __init__(
-            self,
-            version: str = None,
-            os_type: str = None,
-            path: str = None,
-            name: str = "operadriver",
+        self,
+        version: Optional[str] = None,
+        os_type: Optional[str] = None,
+        path: Optional[str] = None,
+        name: str = "operadriver",
             url: str = "https://github.com/operasoftware/operachromiumdriver/"
                        "releases/",
-            latest_release_url: str = "https://api.github.com/repos/"
-                                      "operasoftware/operachromiumdriver/releases/latest",
-            opera_release_tag: str = "https://api.github.com/repos/"
-                                     "operasoftware/operachromiumdriver/releases/tags/{0}",
-            cache_valid_range: int = 1,
-            download_manager: DownloadManager = None,
+        latest_release_url: str = "https://api.github.com/repos/"
+        "operasoftware/operachromiumdriver/releases/latest",
+        opera_release_tag: str = "https://api.github.com/repos/"
+        "operasoftware/operachromiumdriver/releases/tags/{0}",
+        cache_valid_range: int = 1,
+        download_manager: Optional[DownloadManager] = None,
     ):
         super().__init__(path, cache_valid_range, download_manager=download_manager)
 


### PR DESCRIPTION
For arguments that have a default of `None` PEP-484 now recommends
using `Optional[]` (previously these optional types were assumed). It
also recommends type checkers move towards requiring the optional
type to be made explicit, so this commit will future proof for this
behaviour.

See: https://peps.python.org/pep-0484/#union-types

Closes: #419