### PR TITLE
Allow using custom Logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,26 @@ from webdriver_manager.chrome import ChromeDriverManager
 ChromeDriverManager("2.26", cache_valid_range=1).install()
 ```
 
+---
+
+### Custom Logger
+
+If you need to use a custom logger, you can create a logger and set it with `set_logger()`.
+
+```python
+import logging
+from webdriver_manager.core.logger import set_logger
+
+logger = logging.getLogger("custom_logger")
+logger.setLevel(logging.DEBUG)
+logger.addHandler(logging.StreamHandler())
+logger.addHandler(logging.FileHandler("custom.log"))
+
+set_logger(logger)
+```
+
+---
+
 ### Custom HTTP Client
 If you need to add custom HTTP logic like session or proxy you can define your custom HttpClient implementation.
 
@@ -297,6 +317,8 @@ def test_can_get_chrome_driver_with_custom_http_client():
     path = ChromeDriverManager(download_manager=download_manager).install()
     assert os.path.exists(path)
 ```
+
+---
 
 This will make your test automation more elegant and robust!
 

--- a/tests/test_custom_logger.py
+++ b/tests/test_custom_logger.py
@@ -10,8 +10,11 @@ from webdriver_manager.core.logger import log, set_logger, __logger
 
 # Log file path
 log_file = Path(__file__).resolve().parents[1].joinpath(".wdm/logs/WDM_DEBUG.log")
-# Create .wdm/logs directory
-log_file.parent.mkdir(parents=True, exist_ok=True)
+
+# Create the log file if it doesn't exist
+if not log_file.exists():
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+    log_file.touch()
 
 # Cache the old logger to restore it later
 __old_logger = __logger

--- a/tests/test_custom_logger.py
+++ b/tests/test_custom_logger.py
@@ -1,0 +1,45 @@
+"""tests.test_custom_logger.py"""
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from webdriver_manager.core.logger import log, set_logger
+
+
+# Log file path
+log_file = Path(__file__).resolve().parents[1].joinpath(".wdm/logs/WDM_DEBUG.log")
+# Create .wdm/logs directory
+log_file.parent.mkdir(parents=True, exist_ok=True)
+
+
+@pytest.fixture
+def create_logger():
+    """Create a logger."""
+
+    # Create a Custom Debug Logger
+    logger = logging.getLogger("WDM-DEBUG")
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(logging.FileHandler(log_file))
+
+    return logger
+
+
+def test_custom_logger(create_logger):
+    """Test the custom logger."""
+
+    # Set the custom logger
+    set_logger(create_logger)
+
+    # send a log message
+    log("This is a test log message")
+
+    # Check if the log file exists
+    assert log_file.exists()
+
+    # Check if the log file contains the log message
+    assert "This is a test log message" in log_file.read_text()
+
+    # Delete the contents of the log file
+    open(log_file, "w").close()

--- a/tests/test_custom_logger.py
+++ b/tests/test_custom_logger.py
@@ -1,20 +1,10 @@
 """tests.test_custom_logger.py"""
 
 import logging
-from pathlib import Path
 
 import pytest
 
 from webdriver_manager.core.logger import log, set_logger, __logger
-
-
-# Log file path
-log_file = Path(__file__).resolve().parents[1].joinpath(".wdm/logs/WDM_DEBUG.log")
-
-# Create the log file if it doesn't exist
-if not log_file.exists():
-    log_file.parent.mkdir(parents=True, exist_ok=True)
-    log_file.touch()
 
 # Cache the old logger to restore it later
 __old_logger = __logger
@@ -27,28 +17,25 @@ def create_logger():
     # Create a Custom Debug Logger
     logger = logging.getLogger("WDM-DEBUG")
     logger.setLevel(logging.DEBUG)
-    logger.addHandler(logging.FileHandler(log_file))
+    logger.addHandler(logging.StreamHandler())
 
     return logger
 
 
-def test_custom_logger(create_logger):
+def test_custom_logger(capsys, create_logger):
     """Test the custom logger."""
 
     # Set the custom logger
     set_logger(create_logger)
 
     # send a log message
-    log("This is a test log message")
+    log_msg = "This is a test log message from the custom logger"
+    log(log_msg)
 
-    # Check if the log file exists
-    assert log_file.exists()
-
-    # Check if the log file contains the log message
-    assert "This is a test log message" in log_file.read_text()
-
-    # Delete the contents of the log file
-    open(log_file, "w").close()
+    # Check if the log message is in the output
+    captured = capsys.readouterr()
+    assert log_msg in captured.err
+    capsys.close()
 
     # Restore the old logger
     set_logger(__old_logger)

--- a/tests/test_custom_logger.py
+++ b/tests/test_custom_logger.py
@@ -5,13 +5,16 @@ from pathlib import Path
 
 import pytest
 
-from webdriver_manager.core.logger import log, set_logger
+from webdriver_manager.core.logger import log, set_logger, __logger
 
 
 # Log file path
 log_file = Path(__file__).resolve().parents[1].joinpath(".wdm/logs/WDM_DEBUG.log")
 # Create .wdm/logs directory
 log_file.parent.mkdir(parents=True, exist_ok=True)
+
+# Cache the old logger to restore it later
+__old_logger = __logger
 
 
 @pytest.fixture
@@ -43,3 +46,6 @@ def test_custom_logger(create_logger):
 
     # Delete the contents of the log file
     open(log_file, "w").close()
+
+    # Restore the old logger
+    set_logger(__old_logger)

--- a/webdriver_manager/core/logger.py
+++ b/webdriver_manager/core/logger.py
@@ -9,3 +9,24 @@ __logger.addHandler(logging.NullHandler())
 def log(text):
     """Emitting the log message."""
     __logger.log(wdm_log_level(), text)
+
+
+def set_logger(logger):
+    """
+    Set the global logger.
+
+    Parameters
+    ----------
+    logger : logging.Logger
+        The custom logger to use.
+
+    Returns None
+    """
+
+    # Check if the logger is a valid logger
+    if not isinstance(logger, logging.Logger):
+        raise ValueError("The logger must be an instance of logging.Logger")
+
+    # Bind the logger input to the global logger
+    global __logger
+    __logger = logger


### PR DESCRIPTION
Created `set_logger()` to use a custom global logger instead of the default WDM logger.

Added [tests](https://github.com/punitarani/webdriver_manager/blob/master/tests/test_custom_logger.py) and [Documentation ](https://github.com/punitarani/webdriver_manager#custom-logger) for `set_logger()`.