### PR TITLE
Add driver_path property to DriverManager

### DIFF
--- a/webdriver_manager/chrome.py
+++ b/webdriver_manager/chrome.py
@@ -39,3 +39,7 @@ class ChromeDriverManager(DriverManager):
         driver_path = self._get_driver_path(self.driver)
         os.chmod(driver_path, 0o755)
         return driver_path
+
+    @property
+    def driver_path(self) -> str:
+        return self._get_driver_path(self.driver)

--- a/webdriver_manager/core/manager.py
+++ b/webdriver_manager/core/manager.py
@@ -30,3 +30,8 @@ class DriverManager(object):
         file = self._download_manager.download_file(driver.get_url())
         binary_path = self.driver_cache.save_file_to_cache(driver, file)
         return binary_path
+
+    @property
+    def driver_path(self) -> str:
+        """Returns the path to the driver binary"""
+        raise NotImplementedError("Please Implement this method")

--- a/webdriver_manager/firefox.py
+++ b/webdriver_manager/firefox.py
@@ -37,3 +37,7 @@ class GeckoDriverManager(DriverManager):
         driver_path = self._get_driver_path(self.driver)
         os.chmod(driver_path, 0o755)
         return driver_path
+
+    @property
+    def driver_path(self) -> str:
+        return self._get_driver_path(self.driver)

--- a/webdriver_manager/microsoft.py
+++ b/webdriver_manager/microsoft.py
@@ -62,3 +62,7 @@ class EdgeChromiumDriverManager(DriverManager):
         driver_path = self._get_driver_path(self.driver)
         os.chmod(driver_path, 0o755)
         return driver_path
+
+    @property
+    def driver_path(self) -> str:
+        return self._get_driver_path(self.driver)

--- a/webdriver_manager/opera.py
+++ b/webdriver_manager/opera.py
@@ -44,3 +44,7 @@ class OperaDriverManager(DriverManager):
         driver_path = os.path.join(driver_path, os.listdir(driver_path)[0])
         os.chmod(driver_path, 0o755)
         return driver_path
+
+    @property
+    def driver_path(self) -> str:
+        return self._get_driver_path(self.driver)


### PR DESCRIPTION
Allows getting the driver install path without having to `install()` or use the private `_get_driver_path()` method.