### PR TITLE
Skip request to GitHub when cached driver is available

### DIFF
--- a/webdriver_manager/core/driver_cache.py
+++ b/webdriver_manager/core/driver_cache.py
@@ -8,7 +8,7 @@ from webdriver_manager.core.constants import (
     DEFAULT_USER_HOME_CACHE_PATH, ROOT_FOLDER_NAME,
 )
 from webdriver_manager.core.logger import log
-from webdriver_manager.core.utils import get_date_diff, File, save_file, format_version
+from webdriver_manager.core.utils import get_date_diff, File, save_file
 
 
 class DriverCache(object):
@@ -34,20 +34,17 @@ class DriverCache(object):
     def save_file_to_cache(self, driver, file: File):
         driver_name = driver.get_name()
         os_type = driver.get_os_type()
-        driver_version = driver.get_version()
         browser_version = driver.get_browser_version()
-        browser_type = driver.get_browser_type()
-        unified_version = format_version(browser_type, driver_version)
 
         path = os.path.join(
-            self._drivers_directory, driver_name, os_type, unified_version
+            self._drivers_directory, driver_name, os_type
         )
         archive = save_file(file, path)
         files = archive.unpack(path)
         binary = self.__get_binary(files, driver_name)
         binary_path = os.path.join(path, binary)
         self.__save_metadata(
-            browser_version, driver_name, os_type, unified_version, binary_path
+            browser_version, driver_name, os_type, binary_path
         )
         log(f"Driver has been saved in cache [{path}]")
         return binary_path
@@ -67,7 +64,6 @@ class DriverCache(object):
             browser_version,
             driver_name,
             os_type,
-            driver_version,
             binary_path,
             date=None,
     ):
@@ -76,7 +72,7 @@ class DriverCache(object):
 
         metadata = self.get_metadata()
 
-        key = f"{os_type}_{driver_name}_{driver_version}_for_{browser_version}"
+        key = f"{os_type}_{driver_name}_for_{browser_version}"
 
         data = {
             key: {
@@ -93,21 +89,18 @@ class DriverCache(object):
         """Find driver by '{os_type}_{driver_name}_{driver_version}_{browser_version}'."""
         os_type = driver.get_os_type()
         driver_name = driver.get_name()
-        driver_version = driver.get_version()
         browser_version = driver.get_browser_version()
-        browser_type = driver.get_browser_type()
-        unified_version = format_version(browser_type, driver_version)
-
+        
         metadata = self.get_metadata()
 
-        key = f"{os_type}_{driver_name}_{unified_version}_for_{browser_version}"
+        key = f"{os_type}_{driver_name}_for_{browser_version}"
         if key not in metadata:
             log(
                 f"There is no [{os_type}] {driver_name} for browser {browser_version} in cache"
             )
             return None
 
-        path = os.path.join(self._drivers_directory, driver_name, os_type, unified_version)
+        path = os.path.join(self._drivers_directory, driver_name, os_type)
 
         driver_binary_name = driver.get_binary_name()
         binary_path = os.path.join(path, driver_binary_name)

--- a/webdriver_manager/core/utils.py
+++ b/webdriver_manager/core/utils.py
@@ -225,17 +225,6 @@ def get_browser_version_from_os(browser_type=None):
         raise Exception(f"Can not find browser {browser_type} installed in your system!!!")
 
 
-def format_version(browser_type, version):
-    if not version or version == 'latest':
-        return 'latest'
-    try:
-        pattern = PATTERN[browser_type]
-        result = re.search(pattern, version)
-        return result.group(0) if result else version
-    except:
-        return "latest"
-
-
 def get_browser_version(browser_type, metadata):
     pattern = PATTERN[browser_type]
     version_from_os = metadata['version']


### PR DESCRIPTION
Queries to GitHub were done even when a valid cached driver was available for the desired browser. This MR aims to solve this situation by avoiding making requests while a valid cached driver is available. This solves https://github.com/SergeyPirogov/webdriver_manager/issues/442.