### PR TITLE
Fix #422 #442 #464

### DIFF
--- a/tests/test_chrome_driver.py
+++ b/tests/test_chrome_driver.py
@@ -63,7 +63,7 @@ def test_driver_with_ssl_verify_disabled_can_be_downloaded(ssl_verify_enable):
 
 
 def test_chrome_manager_cached_driver_with_selenium():
-    custom_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "custom")
+    custom_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "custom-cache")
     manager = ChromeDriverManager(path=custom_path)
     driver = webdriver.Chrome(manager.install())
     driver.get("http://automation-remarks.com")

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -35,7 +35,7 @@ def test_can_download_chrome_driver(delete_drivers_dir, version):
                           latest_release_url="http://chromedriver.storage.googleapis.com/LATEST_RELEASE",
                           chrome_type=ChromeType.GOOGLE, http_client=WDMHttpClient())
 
-    file = download_manager.download_file(driver.get_url())
+    file = download_manager.download_file(driver.get_driver_download_url())
     assert file.filename == "driver.zip"
     archive = save_file(file, DEFAULT_PROJECT_ROOT_CACHE_PATH)
     assert "chromedriver.exe" in archive.unpack(DEFAULT_PROJECT_ROOT_CACHE_PATH)

--- a/webdriver_manager/core/driver.py
+++ b/webdriver_manager/core/driver.py
@@ -21,6 +21,7 @@ class Driver(object):
             self._os_type = utils.os_type()
         self._latest_release_url = latest_release_url
         self._http_client = http_client
+        self._browser_version = None
 
     @property
     def auth_header(self):
@@ -44,15 +45,17 @@ class Driver(object):
             try:
                 return self.get_latest_release_version()
             except Exception:
-                return self.get_browser_version()
+                return self.get_browser_version_from_os()
         return self._version
 
     def get_latest_release_version(self):
         # type: () -> str
         raise NotImplementedError("Please implement this method")
 
-    def get_browser_version(self):
-        return get_browser_version_from_os(self.get_browser_type())
+    def get_browser_version_from_os(self):
+        if self._browser_version is None:
+            self._browser_version = get_browser_version_from_os(self.get_browser_type())
+        return self._browser_version
 
     def get_browser_type(self):
         raise NotImplementedError("Please implement this method")

--- a/webdriver_manager/core/driver.py
+++ b/webdriver_manager/core/driver.py
@@ -39,7 +39,7 @@ class Driver(object):
         return self._os_type
 
     def get_driver_download_url(self):
-        return f"{self._url}/{self.get_driver_version_to_download()}/{self.get_name()}_{self.get_os_type()}.zip"
+        return f"{self._url}/{self.get_driver_version_to_download()}/{self._name}_{self._os_type}.zip"
 
     def get_driver_version_to_download(self):
         """
@@ -56,6 +56,13 @@ class Driver(object):
         raise NotImplementedError("Please implement this method")
 
     def get_browser_version_from_os(self):
+        """
+        Use-cases:
+        - for key in metadata;
+        - for printing nice logs;
+        - for fallback if version was not set at all.
+        Note: the fallback may have collisions in user cases when previous browser was not uninstalled properly.
+        """
         if self._browser_version is None:
             self._browser_version = get_browser_version_from_os(self.get_browser_type())
         return self._browser_version

--- a/webdriver_manager/core/driver.py
+++ b/webdriver_manager/core/driver.py
@@ -22,6 +22,7 @@ class Driver(object):
         self._latest_release_url = latest_release_url
         self._http_client = http_client
         self._browser_version = None
+        self._driver_to_download_version = None
 
     @property
     def auth_header(self):
@@ -38,15 +39,17 @@ class Driver(object):
         return self._os_type
 
     def get_url(self):
-        return f"{self._url}/{self.get_version()}/{self.get_name()}_{self.get_os_type()}.zip"
+        return f"{self._url}/{self.get_driver_version_to_download()}/{self.get_name()}_{self.get_os_type()}.zip"
 
-    def get_version(self):
-        if not self._version:
-            try:
-                return self.get_latest_release_version()
-            except Exception:
-                return self.get_browser_version_from_os()
-        return self._version
+    def get_driver_version_to_download(self):
+        """
+        Downloads version from parameter if version not None or "latest".
+        Downloads latest, if version is "latest" or browser could not been determined.
+        Downloads determined browser version driver in all other ways as a bonus fallback for lazy users.
+        """
+        if not self._driver_to_download_version:
+            self._driver_to_download_version = self._version if self._version not in (None, "latest") else self.get_latest_release_version()
+        return self._driver_to_download_version
 
     def get_latest_release_version(self):
         # type: () -> str

--- a/webdriver_manager/core/driver.py
+++ b/webdriver_manager/core/driver.py
@@ -38,7 +38,7 @@ class Driver(object):
     def get_os_type(self):
         return self._os_type
 
-    def get_url(self):
+    def get_driver_download_url(self):
         return f"{self._url}/{self.get_driver_version_to_download()}/{self.get_name()}_{self.get_os_type()}.zip"
 
     def get_driver_version_to_download(self):

--- a/webdriver_manager/core/driver_cache.py
+++ b/webdriver_manager/core/driver_cache.py
@@ -34,7 +34,7 @@ class DriverCache(object):
     def save_file_to_cache(self, driver, file: File):
         driver_name = driver.get_name()
         os_type = driver.get_os_type()
-        driver_version = driver.get_version()
+        driver_version = driver.get_driver_version_to_download()
         browser_version = driver.get_browser_version_from_os()
         browser_type = driver.get_browser_type()
         unified_version = format_version(browser_type, driver_version)
@@ -93,7 +93,7 @@ class DriverCache(object):
         """Find driver by '{os_type}_{driver_name}_{driver_version}_{browser_version}'."""
         os_type = driver.get_os_type()
         driver_name = driver.get_name()
-        driver_version = driver.get_version()
+        driver_version = driver.get_driver_version_to_download()
         browser_version = driver.get_browser_version_from_os()
         browser_type = driver.get_browser_type()
         unified_version = format_version(browser_type, driver_version)

--- a/webdriver_manager/core/driver_cache.py
+++ b/webdriver_manager/core/driver_cache.py
@@ -35,7 +35,7 @@ class DriverCache(object):
         driver_name = driver.get_name()
         os_type = driver.get_os_type()
         driver_version = driver.get_version()
-        browser_version = driver.get_browser_version()
+        browser_version = driver.get_browser_version_from_os()
         browser_type = driver.get_browser_type()
         unified_version = format_version(browser_type, driver_version)
 
@@ -94,7 +94,7 @@ class DriverCache(object):
         os_type = driver.get_os_type()
         driver_name = driver.get_name()
         driver_version = driver.get_version()
-        browser_version = driver.get_browser_version()
+        browser_version = driver.get_browser_version_from_os()
         browser_type = driver.get_browser_type()
         unified_version = format_version(browser_type, driver_version)
 

--- a/webdriver_manager/core/driver_cache.py
+++ b/webdriver_manager/core/driver_cache.py
@@ -32,16 +32,14 @@ class DriverCache(object):
         self._drivers_directory = os.path.join(self._root_dir, self._drivers_root)
         self.valid_range = valid_range
         self._cache_key_driver_version = None
+        self._driver_binary_path = None
 
-    def save_file_to_cache(self, driver, file: File):
+    def save_file_to_cache(self, driver: Driver, file: File):
         driver_name = driver.get_name()
         os_type = driver.get_os_type()
         driver_version = self.get_cache_key_driver_version(driver)
         browser_version = driver.get_browser_version_from_os()
-
-        path = os.path.join(
-            self._drivers_directory, driver_name, os_type, driver_version
-        )
+        path = self.__get_path(driver)
         archive = save_file(file, path)
         files = archive.unpack(path)
         binary = self.__get_binary(files, driver_name)
@@ -137,3 +135,13 @@ class DriverCache(object):
         if self._cache_key_driver_version is None:
             self._cache_key_driver_version = "latest" if driver._version in (None, "latest") else driver._version
         return self._cache_key_driver_version
+
+    def __get_path(self, driver: Driver):
+        if self._driver_binary_path is None:
+            self._driver_binary_path = os.path.join(
+                self._drivers_directory,
+                driver.get_name(),
+                driver.get_os_type(),
+                driver.get_driver_version_to_download(),
+            )
+        return self._driver_binary_path

--- a/webdriver_manager/core/driver_cache.py
+++ b/webdriver_manager/core/driver_cache.py
@@ -8,7 +8,7 @@ from webdriver_manager.core.constants import (
     DEFAULT_USER_HOME_CACHE_PATH, ROOT_FOLDER_NAME,
 )
 from webdriver_manager.core.logger import log
-from webdriver_manager.core.utils import get_date_diff, File, save_file, format_version
+from webdriver_manager.core.utils import get_date_diff, File, save_file
 
 
 class DriverCache(object):
@@ -36,18 +36,16 @@ class DriverCache(object):
         os_type = driver.get_os_type()
         driver_version = driver.get_driver_version_to_download()
         browser_version = driver.get_browser_version_from_os()
-        browser_type = driver.get_browser_type()
-        unified_version = format_version(browser_type, driver_version)
 
         path = os.path.join(
-            self._drivers_directory, driver_name, os_type, unified_version
+            self._drivers_directory, driver_name, os_type, driver_version
         )
         archive = save_file(file, path)
         files = archive.unpack(path)
         binary = self.__get_binary(files, driver_name)
         binary_path = os.path.join(path, binary)
         self.__save_metadata(
-            browser_version, driver_name, os_type, unified_version, binary_path
+            browser_version, driver_name, os_type, driver_version, binary_path
         )
         log(f"Driver has been saved in cache [{path}]")
         return binary_path
@@ -95,19 +93,16 @@ class DriverCache(object):
         driver_name = driver.get_name()
         driver_version = driver.get_driver_version_to_download()
         browser_version = driver.get_browser_version_from_os()
-        browser_type = driver.get_browser_type()
-        unified_version = format_version(browser_type, driver_version)
-
         metadata = self.get_metadata()
 
-        key = f"{os_type}_{driver_name}_{unified_version}_for_{browser_version}"
+        key = f"{os_type}_{driver_name}_{driver_version}_for_{browser_version}"
         if key not in metadata:
             log(
                 f"There is no [{os_type}] {driver_name} for browser {browser_version} in cache"
             )
             return None
 
-        path = os.path.join(self._drivers_directory, driver_name, os_type, unified_version)
+        path = os.path.join(self._drivers_directory, driver_name, os_type, driver_version)
 
         driver_binary_name = driver.get_binary_name()
         binary_path = os.path.join(path, driver_binary_name)

--- a/webdriver_manager/core/driver_cache.py
+++ b/webdriver_manager/core/driver_cache.py
@@ -83,19 +83,13 @@ class DriverCache(object):
 
         key = self.__get_metadata_key(driver)
         if key not in metadata:
-            log(
-                f"There is no [{os_type}] {driver_name} for browser {browser_version} in cache"
-            )
-            return None
-
-        path = os.path.join(self._drivers_directory, driver_name, os_type, driver_version)
-
-        driver_binary_name = driver.get_binary_name()
-        binary_path = os.path.join(path, driver_binary_name)
-        if not os.path.exists(binary_path):
+            log(f'There is no [{os_type}] {driver_name} "{driver_version}" for browser "{browser_version}" in cache')
             return None
 
         driver_info = metadata[key]
+        path = driver_info["binary_path"]
+        if not os.path.exists(path):
+            return None
 
         if not self.__is_valid(driver_info):
             return None

--- a/webdriver_manager/core/manager.py
+++ b/webdriver_manager/core/manager.py
@@ -27,6 +27,6 @@ class DriverManager(object):
         if binary_path:
             return binary_path
 
-        file = self._download_manager.download_file(driver.get_url())
+        file = self._download_manager.download_file(driver.get_driver_download_url())
         binary_path = self.driver_cache.save_file_to_cache(driver, file)
         return binary_path

--- a/webdriver_manager/core/utils.py
+++ b/webdriver_manager/core/utils.py
@@ -40,6 +40,8 @@ def save_file(file: File, directory: str):
     archive_path = f"{directory}{os.sep}{file.filename}"
     with open(archive_path, "wb") as code:
         code.write(file.content)
+    if not os.path.exists(archive_path):
+        raise FileExistsError(f"No file has been saved on such path {archive_path}")
     return Archive(archive_path, os_type=os_name())
 
 

--- a/webdriver_manager/core/utils.py
+++ b/webdriver_manager/core/utils.py
@@ -227,22 +227,6 @@ def get_browser_version_from_os(browser_type=None):
         return None
 
 
-def get_browser_version(browser_type, metadata):
-    pattern = PATTERN[browser_type]
-    version_from_os = metadata['version']
-    result = re.search(pattern, version_from_os)
-    version = result.group(0) if version_from_os else None
-    if not version:
-        log(
-            f"Could not get version for {browser_type}. "
-            f"Is {browser_type} installed?"
-        )
-    else:
-        log(f"Current {browser_type} version is {version}")
-
-    return version
-
-
 def read_version_from_cmd(cmd, pattern):
     with subprocess.Popen(
             cmd,

--- a/webdriver_manager/core/utils.py
+++ b/webdriver_manager/core/utils.py
@@ -222,18 +222,7 @@ def get_browser_version_from_os(browser_type=None):
         version = read_version_from_cmd(cmd_mapping, pattern)
         return version
     except Exception:
-        raise Exception(f"Can not find browser {browser_type} installed in your system!!!")
-
-
-def format_version(browser_type, version):
-    if not version or version == 'latest':
-        return 'latest'
-    try:
-        pattern = PATTERN[browser_type]
-        result = re.search(pattern, version)
-        return result.group(0) if result else version
-    except:
-        return "latest"
+        return None
 
 
 def get_browser_version(browser_type, metadata):

--- a/webdriver_manager/drivers/chrome.py
+++ b/webdriver_manager/drivers/chrome.py
@@ -1,4 +1,5 @@
 from packaging import version
+
 from webdriver_manager.core.driver import Driver
 from webdriver_manager.core.logger import log
 from webdriver_manager.core.utils import ChromeType, is_arch, is_mac_os
@@ -20,6 +21,7 @@ class ChromeDriver(Driver):
             name, version, os_type, url, latest_release_url, http_client
         )
         self._browser_type = chrome_type
+        self._os_type = self.get_os_type()
 
     def get_os_type(self):
         os_type = super().get_os_type()
@@ -35,28 +37,27 @@ class ChromeDriver(Driver):
         return os_type
 
     def get_driver_download_url(self):
-        browser_version = self.get_driver_version_to_download()
-        os_type = self.get_os_type()
-
+        driver_version_to_download = self.get_driver_version_to_download()
+        os_type = self._os_type
         # For Mac ARM CPUs after version 106.0.5249.61 the format of OS type changed
         # to more unified "mac_arm64". For newer versions, it'll be "mac_arm64"
         # by default, for lower versions we replace "mac_arm64" to old format - "mac64_m1".
-        if version.parse(browser_version) < version.parse("106.0.5249.61") :
+        if version.parse(driver_version_to_download) < version.parse("106.0.5249.61"):
             os_type = os_type.replace("mac_arm64", "mac64_m1")
 
-        return f"{self._url}/{browser_version}/{self.get_name()}_{os_type}.zip"
+        return f"{self._url}/{driver_version_to_download}/{self.get_name()}_{os_type}.zip"
 
     def get_browser_type(self):
         return self._browser_type
 
     def get_latest_release_version(self):
-        browser_version = self.get_browser_version_from_os()
-        log(f"Get LATEST {self._name} version for {self.get_browser_type()} {browser_version}")
+        determined_browser_version = self.get_browser_version_from_os()
+
+        log(f"Get LATEST {self._name} version for {self._browser_type}")
         latest_release_url = (
-            f"{self._latest_release_url}_{browser_version}"
-            if browser_version
-            else self._latest_release_url
+            self._latest_release_url
+            if (self._version == "latest" or determined_browser_version is None)
+            else f"{self._latest_release_url}_{determined_browser_version}"
         )
         resp = self._http_client.get(url=latest_release_url)
-        self._version = resp.text.rstrip()
-        return self._version
+        return resp.text.rstrip()

--- a/webdriver_manager/drivers/chrome.py
+++ b/webdriver_manager/drivers/chrome.py
@@ -50,7 +50,7 @@ class ChromeDriver(Driver):
         return self._browser_type
 
     def get_latest_release_version(self):
-        browser_version = self.get_browser_version()
+        browser_version = self.get_browser_version_from_os()
         log(f"Get LATEST {self._name} version for {self.get_browser_type()} {browser_version}")
         latest_release_url = (
             f"{self._latest_release_url}_{browser_version}"

--- a/webdriver_manager/drivers/chrome.py
+++ b/webdriver_manager/drivers/chrome.py
@@ -35,7 +35,7 @@ class ChromeDriver(Driver):
         return os_type
 
     def get_url(self):
-        browser_version = self.get_version()
+        browser_version = self.get_driver_version_to_download()
         os_type = self.get_os_type()
 
         # For Mac ARM CPUs after version 106.0.5249.61 the format of OS type changed

--- a/webdriver_manager/drivers/chrome.py
+++ b/webdriver_manager/drivers/chrome.py
@@ -34,7 +34,7 @@ class ChromeDriver(Driver):
 
         return os_type
 
-    def get_url(self):
+    def get_driver_download_url(self):
         browser_version = self.get_driver_version_to_download()
         os_type = self.get_os_type()
 

--- a/webdriver_manager/drivers/edge.py
+++ b/webdriver_manager/drivers/edge.py
@@ -22,31 +22,34 @@ class EdgeChromiumDriver(Driver):
             latest_release_url,
             http_client
         )
+        self._os_type = self.get_os_type()
 
     def get_stable_release_version(self):
         """Stable driver version when browser version was not determined."""
-        stable_url = self._latest_release_url.replace(
-            "LATEST_RELEASE", "LATEST_STABLE")
+        stable_url = self._latest_release_url.replace("LATEST_RELEASE", "LATEST_STABLE")
         resp = self._http_client.get(url=stable_url)
         return resp.text.rstrip()
 
     def get_latest_release_version(self) -> str:
-        browser_version = self.get_browser_version_from_os()
-        browser_version = (
-            browser_version if browser_version else self.get_stable_release_version())
-        log(f"Get LATEST {self._name} version for {browser_version} Edge")
-        major_edge_version = browser_version.split(".")[0]
+        determined_browser_version = self.get_browser_version_from_os()
+        log(f"Get LATEST {self._name} version for Edge {determined_browser_version}")
+
+        edge_driver_version_to_download = (
+            self.get_stable_release_version()
+            if (self._version == "latest" or determined_browser_version is None)
+            else determined_browser_version
+        )
+        major_edge_version = edge_driver_version_to_download.split(".")[0]
         latest_release_url = {
             OSType.WIN
-            in self.get_os_type(): f"{self._latest_release_url}_{major_edge_version}_WINDOWS",
+            in self._os_type: f"{self._latest_release_url}_{major_edge_version}_WINDOWS",
             OSType.MAC
-            in self.get_os_type(): f"{self._latest_release_url}_{major_edge_version}_MACOS",
+            in self._os_type: f"{self._latest_release_url}_{major_edge_version}_MACOS",
             OSType.LINUX
-            in self.get_os_type(): f"{self._latest_release_url}_{major_edge_version}_LINUX",
+            in self._os_type: f"{self._latest_release_url}_{major_edge_version}_LINUX",
         }[True]
         resp = self._http_client.get(url=latest_release_url)
-        self._version = resp.text.rstrip()
-        return self._version
+        return resp.text.rstrip()
 
     def get_browser_type(self):
         return ChromeType.MSEDGE

--- a/webdriver_manager/drivers/edge.py
+++ b/webdriver_manager/drivers/edge.py
@@ -31,7 +31,7 @@ class EdgeChromiumDriver(Driver):
         return resp.text.rstrip()
 
     def get_latest_release_version(self) -> str:
-        browser_version = self.get_browser_version()
+        browser_version = self.get_browser_version_from_os()
         browser_version = (
             browser_version if browser_version else self.get_stable_release_version())
         log(f"Get LATEST {self._name} version for {browser_version} Edge")

--- a/webdriver_manager/drivers/firefox.py
+++ b/webdriver_manager/drivers/firefox.py
@@ -25,7 +25,7 @@ class GeckoDriver(Driver):
         self._mozila_release_tag = mozila_release_tag
 
     def get_latest_release_version(self) -> str:
-        browser_version = self.get_browser_version()
+        browser_version = self.get_browser_version_from_os()
         log(f"Get LATEST {self._name} version for {browser_version} firefox")
         resp = self._http_client.get(
             url=self.latest_release_url,

--- a/webdriver_manager/drivers/firefox.py
+++ b/webdriver_manager/drivers/firefox.py
@@ -12,7 +12,7 @@ class GeckoDriver(Driver):
             url,
             latest_release_url,
             mozila_release_tag,
-            http_client
+            http_client,
     ):
         super(GeckoDriver, self).__init__(
             name,
@@ -20,29 +20,30 @@ class GeckoDriver(Driver):
             os_type,
             url,
             latest_release_url,
-            http_client
+            http_client,
         )
         self._mozila_release_tag = mozila_release_tag
+        self._os_type = self.get_os_type()
 
     def get_latest_release_version(self) -> str:
-        browser_version = self.get_browser_version_from_os()
-        log(f"Get LATEST {self._name} version for {browser_version} firefox")
+        determined_browser_version = self.get_browser_version_from_os()
+        log(f"Get LATEST {self._name} version for {determined_browser_version} firefox")
         resp = self._http_client.get(
             url=self.latest_release_url,
             headers=self.auth_header
         )
-        self._version = resp.json()["tag_name"]
-        return self._version
+        return resp.json()["tag_name"]
 
     def get_driver_download_url(self):
         """Like https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-linux64.tar.gz"""
-        log(f"Getting latest mozilla release info for {self.get_driver_version_to_download()}")
+        driver_version_to_download = self.get_driver_version_to_download()
+        log(f"Getting latest mozilla release info for {driver_version_to_download}")
         resp = self._http_client.get(
-            url=self.tagged_release_url(self.get_driver_version_to_download()),
+            url=self.tagged_release_url(driver_version_to_download),
             headers=self.auth_header
         )
         assets = resp.json()["assets"]
-        name = f"{self.get_name()}-{self.get_driver_version_to_download()}-{self.get_os_type()}."
+        name = f"{self.get_name()}-{driver_version_to_download}-{self._os_type}."
         output_dict = [
             asset for asset in assets if asset["name"].startswith(name)]
         return output_dict[0]["browser_download_url"]

--- a/webdriver_manager/drivers/firefox.py
+++ b/webdriver_manager/drivers/firefox.py
@@ -34,7 +34,7 @@ class GeckoDriver(Driver):
         self._version = resp.json()["tag_name"]
         return self._version
 
-    def get_url(self):
+    def get_driver_download_url(self):
         """Like https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-linux64.tar.gz"""
         log(f"Getting latest mozilla release info for {self.get_driver_version_to_download()}")
         resp = self._http_client.get(

--- a/webdriver_manager/drivers/firefox.py
+++ b/webdriver_manager/drivers/firefox.py
@@ -36,13 +36,13 @@ class GeckoDriver(Driver):
 
     def get_url(self):
         """Like https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-linux64.tar.gz"""
-        log(f"Getting latest mozilla release info for {self.get_version()}")
+        log(f"Getting latest mozilla release info for {self.get_driver_version_to_download()}")
         resp = self._http_client.get(
-            url=self.tagged_release_url(self.get_version()),
+            url=self.tagged_release_url(self.get_driver_version_to_download()),
             headers=self.auth_header
         )
         assets = resp.json()["assets"]
-        name = f"{self.get_name()}-{self.get_version()}-{self.get_os_type()}."
+        name = f"{self.get_name()}-{self.get_driver_version_to_download()}-{self.get_os_type()}."
         output_dict = [
             asset for asset in assets if asset["name"].startswith(name)]
         return output_dict[0]["browser_download_url"]

--- a/webdriver_manager/drivers/ie.py
+++ b/webdriver_manager/drivers/ie.py
@@ -28,7 +28,7 @@ class IEDriver(Driver):
         #       like chrome or firefox
 
     def get_latest_release_version(self) -> str:
-        log(f"Get LATEST driver version for {self.get_browser_version()}")
+        log(f"Get LATEST driver version for {self.get_browser_version_from_os()}")
         resp = self._http_client.get(
             url=self.latest_release_url,
             headers=self.auth_header
@@ -82,8 +82,8 @@ class IEDriver(Driver):
     def get_browser_type(self):
         return "msie"
 
-    def get_browser_version(self):
+    def get_browser_version_from_os(self):
         try:
-            return super().get_browser_version()
+            return super().get_browser_version_from_os()
         except:
             return "latest"

--- a/webdriver_manager/drivers/ie.py
+++ b/webdriver_manager/drivers/ie.py
@@ -28,7 +28,7 @@ class IEDriver(Driver):
         #       like chrome or firefox
 
     def get_latest_release_version(self) -> str:
-        log(f"Get LATEST driver version for {self.get_browser_version_from_os()}")
+        log(f"Get LATEST driver version for Internet Explorer")
         resp = self._http_client.get(
             url=self.latest_release_url,
             headers=self.auth_header
@@ -41,20 +41,20 @@ class IEDriver(Driver):
             for asset in release["assets"]
             if asset["name"].startswith(self.get_name())
         )
-        self._version = release["tag_name"].replace("selenium-", "")
-        return self._version
+        return release["tag_name"].replace("selenium-", "")
 
     def get_driver_download_url(self):
         """Like https://github.com/seleniumhq/selenium/releases/download/3.141.59/IEDriverServer_Win32_3.141.59.zip"""
-        log(f"Getting latest ie release info for {self.get_driver_version_to_download()}")
+        driver_version_to_download = self.get_driver_version_to_download()
+        log(f"Getting latest ie release info for {driver_version_to_download}")
         resp = self._http_client.get(
-            url=self.tagged_release_url(self.get_driver_version_to_download()),
+            url=self.tagged_release_url(driver_version_to_download),
             headers=self.auth_header
         )
 
         assets = resp.json()["assets"]
 
-        name = f"{self.get_name()}_{self.os_type}_{self.get_driver_version_to_download()}" + "."
+        name = f"{self._name}_{self.os_type}_{driver_version_to_download}" + "."
         output_dict = [
             asset for asset in assets if asset["name"].startswith(name)]
         return output_dict[0]["browser_download_url"]
@@ -81,9 +81,3 @@ class IEDriver(Driver):
 
     def get_browser_type(self):
         return "msie"
-
-    def get_browser_version_from_os(self):
-        try:
-            return super().get_browser_version_from_os()
-        except:
-            return "latest"

--- a/webdriver_manager/drivers/ie.py
+++ b/webdriver_manager/drivers/ie.py
@@ -46,15 +46,15 @@ class IEDriver(Driver):
 
     def get_url(self):
         """Like https://github.com/seleniumhq/selenium/releases/download/3.141.59/IEDriverServer_Win32_3.141.59.zip"""
-        log(f"Getting latest ie release info for {self.get_version()}")
+        log(f"Getting latest ie release info for {self.get_driver_version_to_download()}")
         resp = self._http_client.get(
-            url=self.tagged_release_url(self.get_version()),
+            url=self.tagged_release_url(self.get_driver_version_to_download()),
             headers=self.auth_header
         )
 
         assets = resp.json()["assets"]
 
-        name = f"{self.get_name()}_{self.os_type}_{self.get_version()}" + "."
+        name = f"{self.get_name()}_{self.os_type}_{self.get_driver_version_to_download()}" + "."
         output_dict = [
             asset for asset in assets if asset["name"].startswith(name)]
         return output_dict[0]["browser_download_url"]

--- a/webdriver_manager/drivers/ie.py
+++ b/webdriver_manager/drivers/ie.py
@@ -44,7 +44,7 @@ class IEDriver(Driver):
         self._version = release["tag_name"].replace("selenium-", "")
         return self._version
 
-    def get_url(self):
+    def get_driver_download_url(self):
         """Like https://github.com/seleniumhq/selenium/releases/download/3.141.59/IEDriverServer_Win32_3.141.59.zip"""
         log(f"Getting latest ie release info for {self.get_driver_version_to_download()}")
         resp = self._http_client.get(

--- a/webdriver_manager/drivers/opera.py
+++ b/webdriver_manager/drivers/opera.py
@@ -22,15 +22,14 @@ class OperaDriver(Driver):
             url=self.latest_release_url,
             headers=self.auth_header
         )
-        self._version = resp.json()["tag_name"]
-        return self._version
+        return resp.json()["tag_name"]
 
     def get_driver_download_url(self) -> str:
         """Like https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.45/operadriver_linux64.zip"""
-        version = self.get_driver_version_to_download()
-        log(f"Getting latest opera release info for {version}")
+        driver_version_to_download = self.get_driver_version_to_download()
+        log(f"Getting latest opera release info for {driver_version_to_download}")
         resp = self._http_client.get(
-            url=self.tagged_release_url(version),
+            url=self.tagged_release_url(driver_version_to_download),
             headers=self.auth_header
         )
         assets = resp.json()["assets"]
@@ -48,9 +47,3 @@ class OperaDriver(Driver):
 
     def get_browser_type(self):
         return "opera"
-
-    def get_browser_version_from_os(self):
-        try:
-            return super().get_browser_version_from_os()
-        except:
-            return "latest"

--- a/webdriver_manager/drivers/opera.py
+++ b/webdriver_manager/drivers/opera.py
@@ -49,8 +49,8 @@ class OperaDriver(Driver):
     def get_browser_type(self):
         return "opera"
 
-    def get_browser_version(self):
+    def get_browser_version_from_os(self):
         try:
-            return super().get_browser_version()
+            return super().get_browser_version_from_os()
         except:
             return "latest"

--- a/webdriver_manager/drivers/opera.py
+++ b/webdriver_manager/drivers/opera.py
@@ -25,8 +25,8 @@ class OperaDriver(Driver):
         self._version = resp.json()["tag_name"]
         return self._version
 
-    def get_url(self) -> str:
-        # https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.45/operadriver_linux64.zip
+    def get_driver_download_url(self) -> str:
+        """Like https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.45/operadriver_linux64.zip"""
         version = self.get_driver_version_to_download()
         log(f"Getting latest opera release info for {version}")
         resp = self._http_client.get(

--- a/webdriver_manager/drivers/opera.py
+++ b/webdriver_manager/drivers/opera.py
@@ -27,7 +27,7 @@ class OperaDriver(Driver):
 
     def get_url(self) -> str:
         # https://github.com/operasoftware/operachromiumdriver/releases/download/v.2.45/operadriver_linux64.zip
-        version = self.get_version()
+        version = self.get_driver_version_to_download()
         log(f"Getting latest opera release info for {version}")
         resp = self._http_client.get(
             url=self.tagged_release_url(version),


### PR DESCRIPTION
Resolves #422 
Resolves #442
Resolves #464 

Fixed queries to GitHubApi when driver found in cache for firefox/ie/opera.
Fixed falling with Exception if browser was not determined, no more falls with this reason from now on.
Fixed metadata and paths storage for "latest".
Fixed version download logic for Chrome/Edge:
- if version="latest" - downloads LATEST_RELEASE for Chrome/Chromiums and LATEST_STABLE for Edge;
- if version=x.x.x - downloads x.x.x;
- if version is None - tries to determine installed browser version, and if fail - downloads like "latest" - LATEST_RELEASE.

Plus:
Great refactoring in Driver and DriverCache which should make them easier to read and support.
Great function call optimizations to make easier to debug webdriver-manager issues.