### PR TITLE
Catch `ConnectionError`

### DIFF
--- a/webdriver_manager/core/http.py
+++ b/webdriver_manager/core/http.py
@@ -1,5 +1,5 @@
 import requests
-from requests import Response
+from requests import Response, exceptions
 
 from webdriver_manager.core.config import ssl_verify, wdm_progress_bar
 from webdriver_manager.core.utils import show_download_progress
@@ -29,7 +29,11 @@ class WDMHttpClient(HttpClient):
         self._ssl_verify = ssl_verify()
 
     def get(self, url, **kwargs) -> Response:
-        resp = requests.get(url=url, verify=self._ssl_verify, stream=True, **kwargs)
+        try:
+            resp = requests.get(
+                url=url, verify=self._ssl_verify, stream=True, **kwargs)
+        except exceptions.ConnectionError:
+            raise ConnectionError(f"Connection error. Are you offline?")
         self.validate_response(resp)
         if wdm_progress_bar():
             show_download_progress(resp)

--- a/webdriver_manager/core/http.py
+++ b/webdriver_manager/core/http.py
@@ -33,7 +33,7 @@ class WDMHttpClient(HttpClient):
             resp = requests.get(
                 url=url, verify=self._ssl_verify, stream=True, **kwargs)
         except exceptions.ConnectionError:
-            raise ConnectionError(f"Connection error. Are you offline?")
+            raise ConnectionError(f"Could not reach host. Are you offline?")
         self.validate_response(resp)
         if wdm_progress_bar():
             show_download_progress(resp)


### PR DESCRIPTION
Simple catcher of `ConnectionError`.

As mentioned in #492 and #493 it can be very confusing to realise that there is a connectivity issue.
Here we could catch this by checking for `requests.exceptions.ConnectionError` and raising it for more human readable output without truncating any other traces.