### PR TITLE
Don't install tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
     python_requires=">=3.7",
     long_description=readme,
     long_description_content_type="text/markdown",
-    packages=setuptools.find_packages(exclude=['tests']),
+    packages=setuptools.find_packages(include=['webdriver_manager*']),
     include_package_data=True,
     version='3.8.6',
     description='Library provides the way to automatically manage drivers for different browsers',


### PR DESCRIPTION
Resolves https://github.com/SergeyPirogov/webdriver_manager/issues/505. Thought I'd give you a hand :)

When building and installing the package, no tests are included:

```shell
$ python setup.py build
/usr/lib/python3.10/site-packages/setuptools/dist.py:788: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
  warnings.warn(
running build
running build_py
creating build
creating build/lib
creating build/lib/webdriver_manager
copying webdriver_manager/microsoft.py -> build/lib/webdriver_manager
copying webdriver_manager/opera.py -> build/lib/webdriver_manager
copying webdriver_manager/__init__.py -> build/lib/webdriver_manager
copying webdriver_manager/chrome.py -> build/lib/webdriver_manager
copying webdriver_manager/firefox.py -> build/lib/webdriver_manager
creating build/lib/webdriver_manager/core
copying webdriver_manager/core/http.py -> build/lib/webdriver_manager/core
copying webdriver_manager/core/utils.py -> build/lib/webdriver_manager/core
copying webdriver_manager/core/archive.py -> build/lib/webdriver_manager/core
copying webdriver_manager/core/driver.py -> build/lib/webdriver_manager/core
copying webdriver_manager/core/config.py -> build/lib/webdriver_manager/core
copying webdriver_manager/core/constants.py -> build/lib/webdriver_manager/core
copying webdriver_manager/core/__init__.py -> build/lib/webdriver_manager/core
copying webdriver_manager/core/driver_cache.py -> build/lib/webdriver_manager/core
copying webdriver_manager/core/download_manager.py -> build/lib/webdriver_manager/core
copying webdriver_manager/core/logger.py -> build/lib/webdriver_manager/core
copying webdriver_manager/core/manager.py -> build/lib/webdriver_manager/core
creating build/lib/webdriver_manager/drivers
copying webdriver_manager/drivers/edge.py -> build/lib/webdriver_manager/drivers
copying webdriver_manager/drivers/opera.py -> build/lib/webdriver_manager/drivers
copying webdriver_manager/drivers/ie.py -> build/lib/webdriver_manager/drivers
copying webdriver_manager/drivers/__init__.py -> build/lib/webdriver_manager/drivers
copying webdriver_manager/drivers/chrome.py -> build/lib/webdriver_manager/drivers
copying webdriver_manager/drivers/firefox.py -> build/lib/webdriver_manager/drivers
running egg_info
creating webdriver_manager.egg-info
writing webdriver_manager.egg-info/PKG-INFO
writing dependency_links to webdriver_manager.egg-info/dependency_links.txt
writing requirements to webdriver_manager.egg-info/requires.txt
writing top-level names to webdriver_manager.egg-info/top_level.txt
writing manifest file 'webdriver_manager.egg-info/SOURCES.txt'
adding license file 'LICENSE'
writing manifest file 'webdriver_manager.egg-info/SOURCES.txt'
copying webdriver_manager/py.typed -> build/lib/webdriver_manager
```

```shell
$ python setup.py install --root="pkg" --optimize=1 --skip-build
/usr/lib/python3.10/site-packages/setuptools/dist.py:788: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
  warnings.warn(
running install
/usr/lib/python3.10/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
running install_lib
creating pkg
creating pkg/usr
creating pkg/usr/lib
creating pkg/usr/lib/python3.10
creating pkg/usr/lib/python3.10/site-packages
creating pkg/usr/lib/python3.10/site-packages/webdriver_manager
copying build/lib/webdriver_manager/py.typed -> pkg/usr/lib/python3.10/site-packages/webdriver_manager
creating pkg/usr/lib/python3.10/site-packages/webdriver_manager/core
copying build/lib/webdriver_manager/core/http.py -> pkg/usr/lib/python3.10/site-packages/webdriver_manager/core
copying build/lib/webdriver_manager/core/utils.py -> pkg/usr/lib/python3.10/site-packages/webdriver_manager/core
copying build/lib/webdriver_manager/core/archive.py -> pkg/usr/lib/python3.10/site-packages/webdriver_manager/core
copying build/lib/webdriver_manager/core/driver.py -> pkg/usr/lib/python3.10/site-packages/webdriver_manager/core
copying build/lib/webdriver_manager/core/config.py -> pkg/usr/lib/python3.10/site-packages/webdriver_manager/core
copying build/lib/webdriver_manager/core/constants.py -> pkg/usr/lib/python3.10/site-packages/webdriver_manager/core
copying build/lib/webdriver_manager/core/__init__.py -> pkg/usr/lib/python3.10/site-packages/webdriver_manager/core
copying build/lib/webdriver_manager/core/driver_cache.py -> pkg/usr/lib/python3.10/site-packages/webdriver_manager/core
copying build/lib/webdriver_manager/core/download_manager.py -> pkg/usr/lib/python3.10/site-packages/webdriver_manager/core
copying build/lib/webdriver_manager/core/logger.py -> pkg/usr/lib/python3.10/site-packages/webdriver_manager/core
copying build/lib/webdriver_manager/core/manager.py -> pkg/usr/lib/python3.10/site-packages/webdriver_manager/core
creating pkg/usr/lib/python3.10/site-packages/webdriver_manager/drivers
copying build/lib/webdriver_manager/drivers/edge.py -> pkg/usr/lib/python3.10/site-packages/webdriver_manager/drivers
copying build/lib/webdriver_manager/drivers/opera.py -> pkg/usr/lib/python3.10/site-packages/webdriver_manager/drivers
copying build/lib/webdriver_manager/drivers/ie.py -> pkg/usr/lib/python3.10/site-packages/webdriver_manager/drivers
copying build/lib/webdriver_manager/drivers/__init__.py -> pkg/usr/lib/python3.10/site-packages/webdriver_manager/drivers
copying build/lib/webdriver_manager/drivers/chrome.py -> pkg/usr/lib/python3.10/site-packages/webdriver_manager/drivers
copying build/lib/webdriver_manager/drivers/firefox.py -> pkg/usr/lib/python3.10/site-packages/webdriver_manager/drivers
copying build/lib/webdriver_manager/microsoft.py -> pkg/usr/lib/python3.10/site-packages/webdriver_manager
copying build/lib/webdriver_manager/opera.py -> pkg/usr/lib/python3.10/site-packages/webdriver_manager
copying build/lib/webdriver_manager/__init__.py -> pkg/usr/lib/python3.10/site-packages/webdriver_manager
copying build/lib/webdriver_manager/chrome.py -> pkg/usr/lib/python3.10/site-packages/webdriver_manager
copying build/lib/webdriver_manager/firefox.py -> pkg/usr/lib/python3.10/site-packages/webdriver_manager
byte-compiling pkg/usr/lib/python3.10/site-packages/webdriver_manager/core/http.py to http.cpython-310.pyc
byte-compiling pkg/usr/lib/python3.10/site-packages/webdriver_manager/core/utils.py to utils.cpython-310.pyc
byte-compiling pkg/usr/lib/python3.10/site-packages/webdriver_manager/core/archive.py to archive.cpython-310.pyc
byte-compiling pkg/usr/lib/python3.10/site-packages/webdriver_manager/core/driver.py to driver.cpython-310.pyc
byte-compiling pkg/usr/lib/python3.10/site-packages/webdriver_manager/core/config.py to config.cpython-310.pyc
byte-compiling pkg/usr/lib/python3.10/site-packages/webdriver_manager/core/constants.py to constants.cpython-310.pyc
byte-compiling pkg/usr/lib/python3.10/site-packages/webdriver_manager/core/__init__.py to __init__.cpython-310.pyc
byte-compiling pkg/usr/lib/python3.10/site-packages/webdriver_manager/core/driver_cache.py to driver_cache.cpython-310.pyc
byte-compiling pkg/usr/lib/python3.10/site-packages/webdriver_manager/core/download_manager.py to download_manager.cpython-310.pyc
byte-compiling pkg/usr/lib/python3.10/site-packages/webdriver_manager/core/logger.py to logger.cpython-310.pyc
byte-compiling pkg/usr/lib/python3.10/site-packages/webdriver_manager/core/manager.py to manager.cpython-310.pyc
byte-compiling pkg/usr/lib/python3.10/site-packages/webdriver_manager/drivers/edge.py to edge.cpython-310.pyc
byte-compiling pkg/usr/lib/python3.10/site-packages/webdriver_manager/drivers/opera.py to opera.cpython-310.pyc
byte-compiling pkg/usr/lib/python3.10/site-packages/webdriver_manager/drivers/ie.py to ie.cpython-310.pyc
byte-compiling pkg/usr/lib/python3.10/site-packages/webdriver_manager/drivers/__init__.py to __init__.cpython-310.pyc
byte-compiling pkg/usr/lib/python3.10/site-packages/webdriver_manager/drivers/chrome.py to chrome.cpython-310.pyc
byte-compiling pkg/usr/lib/python3.10/site-packages/webdriver_manager/drivers/firefox.py to firefox.cpython-310.pyc
byte-compiling pkg/usr/lib/python3.10/site-packages/webdriver_manager/microsoft.py to microsoft.cpython-310.pyc
byte-compiling pkg/usr/lib/python3.10/site-packages/webdriver_manager/opera.py to opera.cpython-310.pyc
byte-compiling pkg/usr/lib/python3.10/site-packages/webdriver_manager/__init__.py to __init__.cpython-310.pyc
byte-compiling pkg/usr/lib/python3.10/site-packages/webdriver_manager/chrome.py to chrome.cpython-310.pyc
byte-compiling pkg/usr/lib/python3.10/site-packages/webdriver_manager/firefox.py to firefox.cpython-310.pyc
writing byte-compilation script '/tmp/tmprh2qscw7.py'
/bin/python /tmp/tmprh2qscw7.py
removing /tmp/tmprh2qscw7.py
running install_egg_info
running egg_info
writing webdriver_manager.egg-info/PKG-INFO
writing dependency_links to webdriver_manager.egg-info/dependency_links.txt
writing requirements to webdriver_manager.egg-info/requires.txt
writing top-level names to webdriver_manager.egg-info/top_level.txt
adding license file 'LICENSE'
writing manifest file 'webdriver_manager.egg-info/SOURCES.txt'
Copying webdriver_manager.egg-info to pkg/usr/lib/python3.10/site-packages/webdriver_manager-3.8.6-py3.10.egg-info
running install_scripts
```

```shell
$ ls pkg/usr/lib/python3.10/site-packages/
webdriver_manager  webdriver_manager-3.8.6-py3.10.egg-info
```

When building an sdist, tests are included:

```sh
$ python setup.py sdist --formats=gztar,zip
/usr/lib/python3.10/site-packages/setuptools/dist.py:788: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
  warnings.warn(
running sdist
running egg_info
creating webdriver_manager.egg-info
writing webdriver_manager.egg-info/PKG-INFO
writing dependency_links to webdriver_manager.egg-info/dependency_links.txt
writing requirements to webdriver_manager.egg-info/requires.txt
writing top-level names to webdriver_manager.egg-info/top_level.txt
writing manifest file 'webdriver_manager.egg-info/SOURCES.txt'
adding license file 'LICENSE'
writing manifest file 'webdriver_manager.egg-info/SOURCES.txt'
running check
creating webdriver_manager-3.8.6
creating webdriver_manager-3.8.6/.github
creating webdriver_manager-3.8.6/.github/workflows
creating webdriver_manager-3.8.6/tests
creating webdriver_manager-3.8.6/tests_negative
creating webdriver_manager-3.8.6/tests_xdist
creating webdriver_manager-3.8.6/webdriver_manager
creating webdriver_manager-3.8.6/webdriver_manager.egg-info
creating webdriver_manager-3.8.6/webdriver_manager/core
creating webdriver_manager-3.8.6/webdriver_manager/drivers
copying files to webdriver_manager-3.8.6...
copying .coveragerc -> webdriver_manager-3.8.6
copying .gitignore -> webdriver_manager-3.8.6
copying CHANGELOG.md -> webdriver_manager-3.8.6
copying LICENSE -> webdriver_manager-3.8.6
copying Pipfile -> webdriver_manager-3.8.6
copying Pipfile.lock -> webdriver_manager-3.8.6
copying README.md -> webdriver_manager-3.8.6
copying release-process.rst -> webdriver_manager-3.8.6
copying setup.cfg -> webdriver_manager-3.8.6
copying setup.py -> webdriver_manager-3.8.6
copying .github/FUNDING.yml -> webdriver_manager-3.8.6/.github
copying .github/set_win_reg_keys.ps1 -> webdriver_manager-3.8.6/.github
copying .github/workflows/codeql-analysis.yml -> webdriver_manager-3.8.6/.github/workflows
copying .github/workflows/deploy.yml -> webdriver_manager-3.8.6/.github/workflows
copying .github/workflows/test.yml -> webdriver_manager-3.8.6/.github/workflows
copying .github/workflows/test_xdist.yml -> webdriver_manager-3.8.6/.github/workflows
copying tests/__init__.py -> webdriver_manager-3.8.6/tests
copying tests/conftest.py -> webdriver_manager-3.8.6/tests
copying tests/test_brave_driver.py -> webdriver_manager-3.8.6/tests
copying tests/test_chrome_driver.py -> webdriver_manager-3.8.6/tests
copying tests/test_chromium_driver.py -> webdriver_manager-3.8.6/tests
copying tests/test_custom_http_client.py -> webdriver_manager-3.8.6/tests
copying tests/test_custom_logger.py -> webdriver_manager-3.8.6/tests
copying tests/test_downloader.py -> webdriver_manager-3.8.6/tests
copying tests/test_edge_driver.py -> webdriver_manager-3.8.6/tests
copying tests/test_firefox_manager.py -> webdriver_manager-3.8.6/tests
copying tests/test_ie_driver.py -> webdriver_manager-3.8.6/tests
copying tests/test_opera_manager.py -> webdriver_manager-3.8.6/tests
copying tests/test_silent_global_logs.py -> webdriver_manager-3.8.6/tests
copying tests/test_utils.py -> webdriver_manager-3.8.6/tests
copying tests_negative/__init__.py -> webdriver_manager-3.8.6/tests_negative
copying tests_negative/test_browsers_not_installed.py -> webdriver_manager-3.8.6/tests_negative
copying tests_xdist/__init__.py -> webdriver_manager-3.8.6/tests_xdist
copying tests_xdist/conftest.py -> webdriver_manager-3.8.6/tests_xdist
copying tests_xdist/test_cuncurent_1.py -> webdriver_manager-3.8.6/tests_xdist
copying tests_xdist/test_cuncurent_2.py -> webdriver_manager-3.8.6/tests_xdist
copying webdriver_manager/__init__.py -> webdriver_manager-3.8.6/webdriver_manager
copying webdriver_manager/chrome.py -> webdriver_manager-3.8.6/webdriver_manager
copying webdriver_manager/firefox.py -> webdriver_manager-3.8.6/webdriver_manager
copying webdriver_manager/microsoft.py -> webdriver_manager-3.8.6/webdriver_manager
copying webdriver_manager/opera.py -> webdriver_manager-3.8.6/webdriver_manager
copying webdriver_manager/py.typed -> webdriver_manager-3.8.6/webdriver_manager
copying webdriver_manager.egg-info/PKG-INFO -> webdriver_manager-3.8.6/webdriver_manager.egg-info
copying webdriver_manager.egg-info/SOURCES.txt -> webdriver_manager-3.8.6/webdriver_manager.egg-info
copying webdriver_manager.egg-info/dependency_links.txt -> webdriver_manager-3.8.6/webdriver_manager.egg-info
copying webdriver_manager.egg-info/requires.txt -> webdriver_manager-3.8.6/webdriver_manager.egg-info
copying webdriver_manager.egg-info/top_level.txt -> webdriver_manager-3.8.6/webdriver_manager.egg-info
copying webdriver_manager/core/__init__.py -> webdriver_manager-3.8.6/webdriver_manager/core
copying webdriver_manager/core/archive.py -> webdriver_manager-3.8.6/webdriver_manager/core
copying webdriver_manager/core/config.py -> webdriver_manager-3.8.6/webdriver_manager/core
copying webdriver_manager/core/constants.py -> webdriver_manager-3.8.6/webdriver_manager/core
copying webdriver_manager/core/download_manager.py -> webdriver_manager-3.8.6/webdriver_manager/core
copying webdriver_manager/core/driver.py -> webdriver_manager-3.8.6/webdriver_manager/core
copying webdriver_manager/core/driver_cache.py -> webdriver_manager-3.8.6/webdriver_manager/core
copying webdriver_manager/core/http.py -> webdriver_manager-3.8.6/webdriver_manager/core
copying webdriver_manager/core/logger.py -> webdriver_manager-3.8.6/webdriver_manager/core
copying webdriver_manager/core/manager.py -> webdriver_manager-3.8.6/webdriver_manager/core
copying webdriver_manager/core/utils.py -> webdriver_manager-3.8.6/webdriver_manager/core
copying webdriver_manager/drivers/__init__.py -> webdriver_manager-3.8.6/webdriver_manager/drivers
copying webdriver_manager/drivers/chrome.py -> webdriver_manager-3.8.6/webdriver_manager/drivers
copying webdriver_manager/drivers/edge.py -> webdriver_manager-3.8.6/webdriver_manager/drivers
copying webdriver_manager/drivers/firefox.py -> webdriver_manager-3.8.6/webdriver_manager/drivers
copying webdriver_manager/drivers/ie.py -> webdriver_manager-3.8.6/webdriver_manager/drivers
copying webdriver_manager/drivers/opera.py -> webdriver_manager-3.8.6/webdriver_manager/drivers
Writing webdriver_manager-3.8.6/setup.cfg
creating dist
Creating tar archive
creating 'dist/webdriver_manager-3.8.6.zip' and adding 'webdriver_manager-3.8.6' to it
adding 'webdriver_manager-3.8.6'
adding 'webdriver_manager-3.8.6/webdriver_manager'
adding 'webdriver_manager-3.8.6/webdriver_manager.egg-info'
adding 'webdriver_manager-3.8.6/tests'
adding 'webdriver_manager-3.8.6/tests_negative'
adding 'webdriver_manager-3.8.6/.github'
adding 'webdriver_manager-3.8.6/tests_xdist'
adding 'webdriver_manager-3.8.6/release-process.rst'
adding 'webdriver_manager-3.8.6/README.md'
adding 'webdriver_manager-3.8.6/setup.py'
adding 'webdriver_manager-3.8.6/LICENSE'
adding 'webdriver_manager-3.8.6/.coveragerc'
adding 'webdriver_manager-3.8.6/Pipfile.lock'
adding 'webdriver_manager-3.8.6/CHANGELOG.md'
adding 'webdriver_manager-3.8.6/Pipfile'
adding 'webdriver_manager-3.8.6/setup.cfg'
adding 'webdriver_manager-3.8.6/PKG-INFO'
adding 'webdriver_manager-3.8.6/.gitignore'
adding 'webdriver_manager-3.8.6/webdriver_manager/core'
adding 'webdriver_manager-3.8.6/webdriver_manager/drivers'
adding 'webdriver_manager-3.8.6/webdriver_manager/py.typed'
adding 'webdriver_manager-3.8.6/webdriver_manager/microsoft.py'
adding 'webdriver_manager-3.8.6/webdriver_manager/opera.py'
adding 'webdriver_manager-3.8.6/webdriver_manager/__init__.py'
adding 'webdriver_manager-3.8.6/webdriver_manager/chrome.py'
adding 'webdriver_manager-3.8.6/webdriver_manager/firefox.py'
adding 'webdriver_manager-3.8.6/webdriver_manager/core/http.py'
adding 'webdriver_manager-3.8.6/webdriver_manager/core/utils.py'
adding 'webdriver_manager-3.8.6/webdriver_manager/core/archive.py'
adding 'webdriver_manager-3.8.6/webdriver_manager/core/driver.py'
adding 'webdriver_manager-3.8.6/webdriver_manager/core/config.py'
adding 'webdriver_manager-3.8.6/webdriver_manager/core/constants.py'
adding 'webdriver_manager-3.8.6/webdriver_manager/core/__init__.py'
adding 'webdriver_manager-3.8.6/webdriver_manager/core/driver_cache.py'
adding 'webdriver_manager-3.8.6/webdriver_manager/core/download_manager.py'
adding 'webdriver_manager-3.8.6/webdriver_manager/core/logger.py'
adding 'webdriver_manager-3.8.6/webdriver_manager/core/manager.py'
adding 'webdriver_manager-3.8.6/webdriver_manager/drivers/edge.py'
adding 'webdriver_manager-3.8.6/webdriver_manager/drivers/opera.py'
adding 'webdriver_manager-3.8.6/webdriver_manager/drivers/ie.py'
adding 'webdriver_manager-3.8.6/webdriver_manager/drivers/__init__.py'
adding 'webdriver_manager-3.8.6/webdriver_manager/drivers/chrome.py'
adding 'webdriver_manager-3.8.6/webdriver_manager/drivers/firefox.py'
adding 'webdriver_manager-3.8.6/webdriver_manager.egg-info/SOURCES.txt'
adding 'webdriver_manager-3.8.6/webdriver_manager.egg-info/top_level.txt'
adding 'webdriver_manager-3.8.6/webdriver_manager.egg-info/requires.txt'
adding 'webdriver_manager-3.8.6/webdriver_manager.egg-info/dependency_links.txt'
adding 'webdriver_manager-3.8.6/webdriver_manager.egg-info/PKG-INFO'
adding 'webdriver_manager-3.8.6/tests/test_ie_driver.py'
adding 'webdriver_manager-3.8.6/tests/test_silent_global_logs.py'
adding 'webdriver_manager-3.8.6/tests/test_chromium_driver.py'
adding 'webdriver_manager-3.8.6/tests/conftest.py'
adding 'webdriver_manager-3.8.6/tests/test_brave_driver.py'
adding 'webdriver_manager-3.8.6/tests/test_edge_driver.py'
adding 'webdriver_manager-3.8.6/tests/test_utils.py'
adding 'webdriver_manager-3.8.6/tests/test_firefox_manager.py'
adding 'webdriver_manager-3.8.6/tests/__init__.py'
adding 'webdriver_manager-3.8.6/tests/test_opera_manager.py'
adding 'webdriver_manager-3.8.6/tests/test_custom_http_client.py'
adding 'webdriver_manager-3.8.6/tests/test_custom_logger.py'
adding 'webdriver_manager-3.8.6/tests/test_chrome_driver.py'
adding 'webdriver_manager-3.8.6/tests/test_downloader.py'
adding 'webdriver_manager-3.8.6/tests_negative/test_browsers_not_installed.py'
adding 'webdriver_manager-3.8.6/tests_negative/__init__.py'
adding 'webdriver_manager-3.8.6/.github/workflows'
adding 'webdriver_manager-3.8.6/.github/set_win_reg_keys.ps1'
adding 'webdriver_manager-3.8.6/.github/FUNDING.yml'
adding 'webdriver_manager-3.8.6/.github/workflows/test.yml'
adding 'webdriver_manager-3.8.6/.github/workflows/deploy.yml'
adding 'webdriver_manager-3.8.6/.github/workflows/test_xdist.yml'
adding 'webdriver_manager-3.8.6/.github/workflows/codeql-analysis.yml'
adding 'webdriver_manager-3.8.6/tests_xdist/conftest.py'
adding 'webdriver_manager-3.8.6/tests_xdist/test_cuncurent_1.py'
adding 'webdriver_manager-3.8.6/tests_xdist/test_cuncurent_2.py'
adding 'webdriver_manager-3.8.6/tests_xdist/__init__.py'
removing 'webdriver_manager-3.8.6' (and everything under it)
```

This way packagers building from the sdist can still tests the package, but the tests are not installed to package consumers' systems.