### PR TITLE
Preserve stderr in read_version_from_cmd

### DIFF
--- a/webdriver_manager/core/utils.py
+++ b/webdriver_manager/core/utils.py
@@ -231,7 +231,6 @@ def read_version_from_cmd(cmd, pattern):
     with subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
             stdin=subprocess.DEVNULL,
             shell=True,
     ) as stream:


### PR DESCRIPTION
This respects WDM_LOG_LEVEL when it is not set to zero on https://github.com/SergeyPirogov/webdriver_manager/blob/master/webdriver_manager/core/utils.py#L116 so that a user can see what is going on when their browser binary does not execute.

Previously it appears that log checking line had no effect and the error output was always hidden.