### PR TITLE
Fix TypeError when no browser version found

### DIFF
--- a/webdriver_manager/drivers/chrome.py
+++ b/webdriver_manager/drivers/chrome.py
@@ -53,7 +53,7 @@ class ChromeDriver(Driver):
     def get_latest_release_version(self):
         determined_browser_version = self.get_browser_version_from_os()
         log(f"Get LATEST {self._name} version for {self._browser_type}")
-        if version.parse(determined_browser_version) >= version.parse("113"):
+        if determined_browser_version is not None and version.parse(determined_browser_version) >= version.parse("113"):
             return determined_browser_version
 
         latest_release_url = (


### PR DESCRIPTION
Right now it fails like this:
```
expected string or bytes-like object, got 'NoneType'

File "/function/code/main.py", line 19, in doit
    installed = manager.install()
   File "/function/code/webdriver_manager/chrome.py", line 39, in install
    driver_path = self._get_driver_binary_path(self.driver)
   File "/function/code/webdriver_manager/core/manager.py", line 33, in _get_driver_binary_path
    file = self._download_manager.download_file(driver.get_driver_download_url())
   File "/function/code/webdriver_manager/drivers/chrome.py", line 45, in get_driver_download_url
    driver_version_to_download = self.get_driver_version_to_download()
   File "/function/code/webdriver_manager/core/driver.py", line 51, in get_driver_version_to_download
    else self.get_latest_release_version()
   File "/function/code/webdriver_manager/drivers/chrome.py", line 71, in get_latest_release_version
    if version.parse(determined_browser_version) >= version.parse("113"):
   File "/function/code/packaging/version.py", line 52, in parse
    return Version(version)
   File "/function/code/packaging/version.py", line 196, in __init__
    match = self._regex.search(version)
```