### PR TITLE
Fix the Chrome Download for Versions < 113

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ pytest = "*"
 bump2version = "*"
 pytest-xdist = "*"
 pybrowsers = "*"
+mock = "*"
 
 [packages]
 requests = "*"

--- a/tests/test_chrome_driver.py
+++ b/tests/test_chrome_driver.py
@@ -9,6 +9,7 @@ from mock import patch
 from webdriver_manager.chrome import ChromeDriverManager
 from webdriver_manager.core.constants import ROOT_FOLDER_NAME
 from selenium.webdriver.chrome.service import Service
+from webdriver_manager.core.driver import Driver
 
 from webdriver_manager.core.driver_cache import DriverCacheManager
 from webdriver_manager.core.os_manager import OperationSystemManager
@@ -26,11 +27,11 @@ def test_chrome_manager_with_specific_version(delete_drivers_dir):
     driver_binary = ChromeDriverManager("87.0.4280.88").install()
     assert os.path.exists(driver_binary)
 
-@patch('webdriver_manager.core.driver.get_browser_version_from_os')
-def test_chrome_manager_with_old_detected_version(mock_get_browser, delete_drivers_dir):
-    mock_get_browser.return_value="112.0.5615.165"
-    driver_binary = ChromeDriverManager().install()
-    assert os.path.exists(driver_binary)
+
+@patch.object(Driver, 'get_browser_version_from_os', return_value="112.0.5615.165")
+def test_chrome_manager_with_old_detected_version(mock_version, delete_drivers_dir):
+        driver_binary = ChromeDriverManager().install()
+        assert os.path.exists(driver_binary)
 
 
 def test_106_0_5249_61_chrome_version(delete_drivers_dir):

--- a/tests/test_chrome_driver.py
+++ b/tests/test_chrome_driver.py
@@ -4,6 +4,7 @@ import os
 import pytest
 import browsers
 from selenium import webdriver
+from mock import patch
 
 from webdriver_manager.chrome import ChromeDriverManager
 from webdriver_manager.core.constants import ROOT_FOLDER_NAME
@@ -23,6 +24,12 @@ def test_chrome_manager_with_cache(delete_drivers_dir):
 
 def test_chrome_manager_with_specific_version(delete_drivers_dir):
     driver_binary = ChromeDriverManager("87.0.4280.88").install()
+    assert os.path.exists(driver_binary)
+
+@patch('webdriver_manager.core.driver.get_browser_version_from_os')
+def test_chrome_manager_with_old_detected_version(mock_get_browser, delete_drivers_dir):
+    mock_get_browser.return_value="112.0.5615.165"
+    driver_binary = ChromeDriverManager().install()
     assert os.path.exists(driver_binary)
 
 

--- a/webdriver_manager/drivers/chrome.py
+++ b/webdriver_manager/drivers/chrome.py
@@ -55,7 +55,8 @@ class ChromeDriver(Driver):
         log(f"Get LATEST {self._name} version for {self._browser_type}")
         if determined_browser_version is not None and version.parse(determined_browser_version) >= version.parse("113"):
             return determined_browser_version
-
+        # Remove the build version (the last segment) from determined_browser_version for version < 113
+        determined_browser_version = ".".join(determined_browser_version.split(".")[:3])
         latest_release_url = (
             self._latest_release_url
             if (determined_browser_version is None)


### PR DESCRIPTION


when querying http://chromedriver.storage.googleapis.com/latest_release the versions do not have the last build version and so need to be stripped.

This fix is suggested by @shenchucheng.

I have added a test for this scenario of an detected version < 113
