### PR TITLE
Fix unhandled AttributeError when chrome browser version cannot be determined

### DIFF
--- a/webdriver_manager/drivers/chrome.py
+++ b/webdriver_manager/drivers/chrome.py
@@ -60,13 +60,13 @@ class ChromeDriver(Driver):
             response_dict = json.loads(response.text)
             determined_browser_version = response_dict.get("builds").get(determined_browser_version).get("version")
             return determined_browser_version
-        # Remove the build version (the last segment) from determined_browser_version for version < 113
-        determined_browser_version = ".".join(determined_browser_version.split(".")[:3])
-        latest_release_url = (
-            self._latest_release_url
-            if (determined_browser_version is None)
-            else f"{self._latest_release_url}_{determined_browser_version}"
-        )
+
+        if determined_browser_version is None:
+            latest_release_url = self._latest_release_url
+        else:
+            # Remove the build version (the last segment) from determined_browser_version for version < 113
+            determined_browser_version = ".".join(determined_browser_version.split(".")[:3])
+            latest_release_url = f"{self._latest_release_url}_{determined_browser_version}"
         resp = self._http_client.get(url=latest_release_url)
         return resp.text.rstrip()
 


### PR DESCRIPTION

```py
Traceback (most recent call last):
  ...
  File "D:\app\__pypackages__\3.12\lib\webdriver_manager\chrome.py", line 40, in install
    driver_path = self._get_driver_binary_path(self.driver)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\app\__pypackages__\3.12\lib\webdriver_manager\core\manager.py", line 40, in _get_driver_binary_path
    file = self._download_manager.download_file(driver.get_driver_download_url(os_type))
                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\app\__pypackages__\3.12\lib\webdriver_manager\drivers\chrome.py", line 32, in get_driver_download_url
    driver_version_to_download = self.get_driver_version_to_download()
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\app\__pypackages__\3.12\lib\webdriver_manager\core\driver.py", line 48, in get_driver_version_to_download
    return self.get_latest_release_version()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\app\__pypackages__\3.12\lib\webdriver_manager\drivers\chrome.py", line 64, in get_latest_release_version
    determined_browser_version = ".".join(determined_browser_version.split(".")[:3])
                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'split'
```