### PR TITLE
Allow specifying browser binary path

### DIFF
--- a/webdriver_manager/chrome.py
+++ b/webdriver_manager/chrome.py
@@ -18,12 +18,14 @@ class ChromeDriverManager(DriverManager):
             chrome_type: str = ChromeType.GOOGLE,
             download_manager: Optional[DownloadManager] = None,
             cache_manager: Optional[DriverCacheManager] = None,
-            os_system_manager: Optional[OperationSystemManager] = None
+            os_system_manager: Optional[OperationSystemManager] = None,
+            browser_path: Optional[str] = None
     ):
         super().__init__(
             download_manager=download_manager,
             cache_manager=cache_manager,
-            os_system_manager=os_system_manager
+            os_system_manager=os_system_manager,
+            browser_path=browser_path
         )
 
         self.driver = ChromeDriver(

--- a/webdriver_manager/core/driver_cache.py
+++ b/webdriver_manager/core/driver_cache.py
@@ -16,7 +16,7 @@ from webdriver_manager.core.utils import get_date_diff
 
 
 class DriverCacheManager(object):
-    def __init__(self, root_dir=None, valid_range=1, file_manager=None, 
+    def __init__(self, root_dir=None, valid_range=1, file_manager=None,
                  browser_path: Optional[str] = None):
         self.browser_path = browser_path
         self._root_dir = DEFAULT_USER_HOME_CACHE_PATH
@@ -106,7 +106,7 @@ class DriverCacheManager(object):
             browser_version = self._os_system_manager.get_browser_version_from_os(browser_type)
         else:
             browser_version = self._os_system_manager.get_browser_version_from_path(browser_type, self.browser_path)
-        
+
         if not browser_version:
             return None
 

--- a/webdriver_manager/core/driver_cache.py
+++ b/webdriver_manager/core/driver_cache.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import datetime
 import json
 import os
@@ -15,7 +16,9 @@ from webdriver_manager.core.utils import get_date_diff
 
 
 class DriverCacheManager(object):
-    def __init__(self, root_dir=None, valid_range=1, file_manager=None):
+    def __init__(self, root_dir=None, valid_range=1, file_manager=None, 
+                 browser_path: Optional[str] = None):
+        self.browser_path = browser_path
         self._root_dir = DEFAULT_USER_HOME_CACHE_PATH
         is_wdm_local = wdm_local()
         xdist_worker_id = get_xdist_worker_id()
@@ -98,7 +101,12 @@ class DriverCacheManager(object):
         os_type = self.get_os_type()
         driver_name = driver.get_name()
         browser_type = driver.get_browser_type()
-        browser_version = self._os_system_manager.get_browser_version_from_os(browser_type)
+
+        if self.browser_path is None:
+            browser_version = self._os_system_manager.get_browser_version_from_os(browser_type)
+        else:
+            browser_version = self._os_system_manager.get_browser_version_from_path(browser_type, self.browser_path)
+        
         if not browser_version:
             return None
 

--- a/webdriver_manager/core/manager.py
+++ b/webdriver_manager/core/manager.py
@@ -28,7 +28,8 @@ class DriverManager(object):
             self._os_system_manager = OperationSystemManager()
 
         if not os.access(browser_path, os.X_OK):
-            raise PermissionError(f'Provided browser path is not executable: {browser_path!r}')
+            raise PermissionError(
+                f'Provided browser path is not executable: {browser_path!r}')
         self.browser_path = browser_path
         log("====== WebDriver manager ======")
 

--- a/webdriver_manager/core/manager.py
+++ b/webdriver_manager/core/manager.py
@@ -1,3 +1,6 @@
+from typing import Optional
+import os
+
 from webdriver_manager.core.download_manager import WDMDownloadManager
 from webdriver_manager.core.driver_cache import DriverCacheManager
 from webdriver_manager.core.logger import log
@@ -9,7 +12,8 @@ class DriverManager(object):
             self,
             download_manager=None,
             cache_manager=None,
-            os_system_manager=None
+            os_system_manager=None,
+            browser_path: Optional[str] = None
     ):
         self._cache_manager = cache_manager
         if not self._cache_manager:
@@ -22,6 +26,10 @@ class DriverManager(object):
         self._os_system_manager = os_system_manager
         if not self._os_system_manager:
             self._os_system_manager = OperationSystemManager()
+
+        if not os.access(browser_path, os.X_OK):
+            raise PermissionError(f'Provided browser path is not executable: {browser_path!r}')
+        self.browser_path = browser_path
         log("====== WebDriver manager ======")
 
     @property

--- a/webdriver_manager/core/os_manager.py
+++ b/webdriver_manager/core/os_manager.py
@@ -64,6 +64,16 @@ class OperationSystemManager(object):
     def is_mac_os(os_sys_type):
         return OSType.MAC in os_sys_type
 
+    def get_browser_version_from_path(self, browser_type, browser_path: str):
+        os = OperationSystemManager.get_os_name()
+        if os == OSType.WIN:
+            cmd = f'(Get-Item -Path "{browser_path}").VersionInfo.FileVersion'
+        else:         # Linux, Mac
+            cmd = f'"{browser_path}" --version'
+        pattern = PATTERN[browser_type]
+        version = read_version_from_cmd(cmd, pattern)
+        return version
+
     def get_browser_version_from_os(self, browser_type=None):
         """Return installed browser version."""
         cmd_mapping = {
@@ -154,9 +164,9 @@ class OperationSystemManager(object):
         }
 
         try:
-            cmd_mapping = cmd_mapping[browser_type][OperationSystemManager.get_os_name()]
+            cmd = cmd_mapping[browser_type][OperationSystemManager.get_os_name()]
             pattern = PATTERN[browser_type]
-            version = read_version_from_cmd(cmd_mapping, pattern)
+            version = read_version_from_cmd(cmd, pattern)
             return version
         except Exception:
             return None

--- a/webdriver_manager/firefox.py
+++ b/webdriver_manager/firefox.py
@@ -18,11 +18,13 @@ class GeckoDriverManager(DriverManager):
             mozila_release_tag: str = "https://api.github.com/repos/mozilla/geckodriver/releases/tags/{0}",
             download_manager: Optional[DownloadManager] = None,
             cache_manager: Optional[DriverCacheManager] = None,
-            os_system_manager: Optional[OperationSystemManager] = None
+            os_system_manager: Optional[OperationSystemManager] = None,
+            browser_path: Optional[str] = None
     ):
         super(GeckoDriverManager, self).__init__(
             download_manager=download_manager,
-            cache_manager=cache_manager
+            cache_manager=cache_manager,
+            browser_path=browser_path
         )
 
         self.driver = GeckoDriver(

--- a/webdriver_manager/microsoft.py
+++ b/webdriver_manager/microsoft.py
@@ -19,11 +19,13 @@ class IEDriverManager(DriverManager):
             ie_release_tag: str = "https://api.github.com/repos/seleniumhq/selenium/releases/tags/selenium-{0}",
             download_manager: Optional[DownloadManager] = None,
             cache_manager: Optional[DriverCacheManager] = None,
-            os_system_manager: Optional[OperationSystemManager] = None
+            os_system_manager: Optional[OperationSystemManager] = None,
+            browser_path: Optional[str] = None
     ):
         super().__init__(
             download_manager=download_manager,
-            cache_manager=cache_manager
+            cache_manager=cache_manager,
+            browser_path=browser_path
         )
 
         self.driver = IEDriver(
@@ -52,12 +54,14 @@ class EdgeChromiumDriverManager(DriverManager):
             latest_release_url: str = "https://msedgedriver.azureedge.net/LATEST_RELEASE",
             download_manager: Optional[DownloadManager] = None,
             cache_manager: Optional[DriverCacheManager] = None,
-            os_system_manager: Optional[OperationSystemManager] = None
+            os_system_manager: Optional[OperationSystemManager] = None,
+            browser_path: Optional[str] = None
     ):
         super().__init__(
             download_manager=download_manager,
             cache_manager=cache_manager,
-            os_system_manager=os_system_manager
+            os_system_manager=os_system_manager,
+            browser_path=browser_path
         )
 
         self.driver = EdgeChromiumDriver(

--- a/webdriver_manager/opera.py
+++ b/webdriver_manager/opera.py
@@ -21,11 +21,13 @@ class OperaDriverManager(DriverManager):
                                      "operasoftware/operachromiumdriver/releases/tags/{0}",
             download_manager: Optional[DownloadManager] = None,
             cache_manager: Optional[DriverCacheManager] = None,
-            os_system_manager: Optional[OperationSystemManager] = None
+            os_system_manager: Optional[OperationSystemManager] = None,
+            browser_path: Optional[str] = None
     ):
         super().__init__(
             download_manager=download_manager,
-            cache_manager=cache_manager
+            cache_manager=cache_manager,
+            browser_path=browser_path
         )
 
         self.driver = OperaDriver(


### PR DESCRIPTION
Fixes [Issue 645](https://github.com/SergeyPirogov/webdriver_manager/issues/645).

Add a `binary_path` option to all `DriverManager` classes to manually specify location of browser. This is useful when the browser is installed in a non-standard location.

Example test script using Chrome:
```python
from selenium import webdriver
from selenium.webdriver.chrome.service import Service as ChromeService
from selenium.webdriver.chrome.options import Options as ChromeOptions
from webdriver_manager.chrome import ChromeDriverManager

chrome_path = "/custom/path/to/chrome"

manager = ChromeDriverManager(browser_path=chrome_path)
chromedriver_path = manager.install()

options = ChromeOptions()
options.binary_location = chrome_path
driver = webdriver.Chrome(service=ChromeService(chromedriver_path), options=options)
```