### PR TITLE
Hide STDERR output when looking for proper browser executable.

### DIFF
--- a/webdriver_manager/core/utils.py
+++ b/webdriver_manager/core/utils.py
@@ -40,6 +40,7 @@ def read_version_from_cmd(cmd, pattern):
             cmd,
             stdout=subprocess.PIPE,
             stdin=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
             shell=True,
     ) as stream:
         stdout = stream.communicate()[0].decode()


### PR DESCRIPTION
When the library tries to found browser version, then it runs (for example) this command:

```
google-chrome --version || google-chrome-stable --version || google-chrome-beta --version || google-chrome-dev --version
```

When the first executable (the `google-chrome` in example above) is not found, then this error message is printed to STDERR:

```
/bin/sh: line 1: google-chrome: command not found
```

This pull request redirects STDERR of the above command to /dev/null so the message will not affect error output of the application.