### PR TITLE
Fix __get_binary by excluding third party licenses

### DIFF
--- a/webdriver_manager/core/driver_cache.py
+++ b/webdriver_manager/core/driver_cache.py
@@ -68,6 +68,8 @@ class DriverCacheManager(object):
         for f in files:
             if 'LICENSE' in f:
                 continue
+            if 'THIRD_PARTY' in f:
+                continue
             if driver_name in f:
                 return f
 


### PR DESCRIPTION
Add an exclusion for files containing `THIRD_PARTY` when retrieving for the driver binary

Fixing #663 
and duplicates:
#664 
#665 