### PR TITLE
 Added support for all (Firefox, Edge, Chrome) versions templates to Reg. Exp. Patterns

### DIFF
--- a/webdriver_manager/core/os_manager.py
+++ b/webdriver_manager/core/os_manager.py
@@ -19,9 +19,9 @@ class OSType(object):
 
 
 PATTERN = {
-    ChromeType.CHROMIUM: r"\d+\.\d+\.\d+",
-    ChromeType.GOOGLE: r"\d+\.\d+\.\d+",
-    ChromeType.MSEDGE: r"\d+\.\d+\.\d+",
+    ChromeType.CHROMIUM: r"\d+\.\d+\.\d+\.\d+",
+    ChromeType.GOOGLE: r"\d+\.\d+\.\d+\.\d+",
+    ChromeType.MSEDGE: r"\d+\.\d+\.\d+\.\d+",
     "brave-browser": r"\d+\.\d+\.\d+(\.\d+)?",
     "firefox": r"(\d+\.\d+\.\d+)|(\d+\.\d+)",
 }

--- a/webdriver_manager/core/os_manager.py
+++ b/webdriver_manager/core/os_manager.py
@@ -23,7 +23,7 @@ PATTERN = {
     ChromeType.GOOGLE: r"\d+\.\d+\.\d+",
     ChromeType.MSEDGE: r"\d+\.\d+\.\d+",
     "brave-browser": r"\d+\.\d+\.\d+(\.\d+)?",
-    "firefox": r"(\d+.\d+)",
+    "firefox": r"(\d+\.\d+\.\d+)|(\d+\.\d+)",
 }
 
 


### PR DESCRIPTION
Edge and Chrome versions always look like X.X.X.X.

Firefox versions: X.X.X or X.X