### PR TITLE
Support linux and win ARM on firefox

### DIFF
--- a/webdriver_manager/firefox.py
+++ b/webdriver_manager/firefox.py
@@ -42,10 +42,6 @@ class GeckoDriverManager(DriverManager):
 
     def get_os_type(self):
         os_type = super().get_os_type()
-        if not self._os_system_manager.is_mac_os(os_type):
-            return os_type
-
-        macos = 'macos'
         if self._os_system_manager.is_arch(os_type):
-            return f"{macos}-aarch64"
-        return macos
+            os_type = f'{self._os_system_manager.get_os_name()}{"os" if self._os_system_manager.is_mac_os(os_type) else ""}-aarch{self._os_system_manager.get_os_architecture()}'
+        return os_type


### PR DESCRIPTION
## Why 
My raspberry pi 4 was failing to start because the incorrect driver binary path was being used.

## My Config
```
Operating System: Debian GNU/Linux 12 (bookworm)  
          Kernel: Linux 6.6.51+rpt-rpi-v8
    Architecture: arm64
```

## The Change
Any os deemed `arm` should now use the correct binary.
Previously, only mac was using the correct `macos-aarch64` binary.

## Validation
I tested these changes on `macos-aarch64` and `linux-aarch64`
