### PR TITLE
`msedgedriver` storage moved from `msedgedriver.azureedge.net` to `msedgedriver.microsoft.com`

### DIFF
--- a/webdriver_manager/microsoft.py
+++ b/webdriver_manager/microsoft.py
@@ -48,8 +48,8 @@ class EdgeChromiumDriverManager(DriverManager):
             self,
             version: Optional[str] = None,
             name: str = "edgedriver",
-            url: str = "https://msedgedriver.azureedge.net",
-            latest_release_url: str = "https://msedgedriver.azureedge.net/LATEST_RELEASE",
+            url: str = "https://msedgedriver.microsoft.com",
+            latest_release_url: str = "https://msedgedriver.microsoft.com/LATEST_RELEASE",
             download_manager: Optional[DownloadManager] = None,
             cache_manager: Optional[DriverCacheManager] = None,
             os_system_manager: Optional[OperationSystemManager] = None


### PR DESCRIPTION
`msedgedriver` storage moved from `msedgedriver.azureedge.net` to `msedgedriver.microsoft.com`
This change made by Microsoft breaks `get edgedriver`.
Need to update the links to fix msedgedriver downloads.