### PR TITLE
Handle missing Chrome for Testing metadata for Chromium-based browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ---
 
+## 4.0.3
+- Fixed Chrome/Chromium driver resolution for Chrome for Testing when exact build metadata is missing by adding milestone fallback, proper Chrome for Testing download resolution, and readable error handling. (#637, #642, #669, #691)
+
+---
+
 ## 4.0.1
 - Add correct os_type determination while on cygwin
 - Up-to date README.md

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,33 +16,30 @@ def list_browsers():
 
 @pytest.fixture()
 def delete_drivers_dir():
-    try:
-        if os.path.exists(DEFAULT_USER_HOME_CACHE_PATH):
-            log(f"Delete {DEFAULT_USER_HOME_CACHE_PATH} folder")
-            shutil.rmtree(DEFAULT_USER_HOME_CACHE_PATH)
-        if os.path.exists(DEFAULT_PROJECT_ROOT_CACHE_PATH):
-            log(f"Delete {DEFAULT_PROJECT_ROOT_CACHE_PATH} folder")
-            shutil.rmtree(DEFAULT_PROJECT_ROOT_CACHE_PATH)
+    def remove_if_exists(path):
+        if os.path.exists(path):
+            log(f"Delete {path} folder")
+            shutil.rmtree(path)
 
-        if os.path.exists(os.path.join(sys.path[0], 'custom-cache', ROOT_FOLDER_NAME)):
-            log(f"Delete {os.path.join(sys.path[0], 'custom-cache')} folder")
-            shutil.rmtree(os.path.join(sys.path[0], 'custom-cache'))
-        if os.path.exists(os.path.join(sys.path[0], 'custom', ROOT_FOLDER_NAME)):
-            log(f"Delete {os.path.join(sys.path[0], 'custom')} folder")
-            shutil.rmtree(os.path.join(sys.path[0], 'custom'))
-        if os.path.exists(os.path.join(sys.path[0], 'ssl_disabled', ROOT_FOLDER_NAME)):
-            log(f"Delete {os.path.join(sys.path[0], 'ssl_disabled')} folder")
-            shutil.rmtree(os.path.join(sys.path[0], 'ssl_disabled'))
-        
-        if os.path.exists(os.path.join(os.path.expanduser("~"), 'custom-cache', ROOT_FOLDER_NAME)):
-            log(f"Delete {os.path.join(os.path.expanduser("~"), 'custom-cache')} folder")
-            shutil.rmtree(os.path.join(os.path.expanduser("~"), 'custom-cache'))
-        if os.path.exists(os.path.join(os.path.expanduser("~"), 'custom', ROOT_FOLDER_NAME)):
-            log(f"Delete {os.path.join(os.path.expanduser("~"), 'custom')} folder")
-            shutil.rmtree(os.path.join(os.path.expanduser("~"), 'custom'))
-        if os.path.exists(os.path.join(os.path.expanduser("~"), 'ssl_disabled', ROOT_FOLDER_NAME)):
-            log(f"Delete {os.path.join(os.path.expanduser("~"), 'ssl_disabled')} folder")
-            shutil.rmtree(os.path.join(os.path.expanduser("~"), 'ssl_disabled'))
+    project_cache_paths = [
+        os.path.join(sys.path[0], "custom-cache"),
+        os.path.join(sys.path[0], "custom"),
+        os.path.join(sys.path[0], "ssl_disabled"),
+    ]
+
+    user_home_cache_paths = [
+        os.path.join(os.path.expanduser("~"), "custom-cache"),
+        os.path.join(os.path.expanduser("~"), "custom"),
+        os.path.join(os.path.expanduser("~"), "ssl_disabled"),
+    ]
+
+    try:
+        remove_if_exists(DEFAULT_USER_HOME_CACHE_PATH)
+        remove_if_exists(DEFAULT_PROJECT_ROOT_CACHE_PATH)
+
+        for cache_path in project_cache_paths + user_home_cache_paths:
+            if os.path.exists(os.path.join(cache_path, ROOT_FOLDER_NAME)):
+                remove_if_exists(cache_path)
 
     except PermissionError as e:
         print(f"Can not delete folder {e}")

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,0 +1,49 @@
+import json
+
+from webdriver_manager.core.os_manager import ChromeType
+from webdriver_manager.drivers.chrome import ChromeDriver
+
+
+class ResponseMock:
+    def __init__(self, body):
+        self.body = body
+        self.text = body if isinstance(body, str) else json.dumps(body)
+
+    def json(self):
+        if isinstance(self.body, str):
+            return json.loads(self.body)
+        return self.body
+
+
+class HttpClientMock:
+    def __init__(self, responses):
+        self.responses = responses
+        self.requested_urls = []
+
+    def get(self, url, **kwargs):
+        self.requested_urls.append(url)
+        return ResponseMock(self.responses[url])
+
+
+class OperationSystemManagerMock:
+    def __init__(self, browser_version):
+        self.browser_version = browser_version
+
+    def get_browser_version_from_os(self, browser_type=None):
+        return self.browser_version
+
+
+def chrome_driver_for(browser_version, responses, chrome_type=ChromeType.CHROMIUM):
+    http_client = HttpClientMock(responses)
+    driver = ChromeDriver(
+        name="chromedriver",
+        driver_version=None,
+        url="https://storage.googleapis.com/chrome-for-testing-public/",
+        latest_release_url=(
+            "https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_STABLE"
+        ),
+        http_client=http_client,
+        os_system_manager=OperationSystemManagerMock(browser_version),
+        chrome_type=chrome_type,
+    )
+    return driver, http_client

--- a/tests/test_brave_driver.py
+++ b/tests/test_brave_driver.py
@@ -6,10 +6,12 @@ import pytest
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service
 
+from tests.helper import chrome_driver_for
 from webdriver_manager.chrome import ChromeDriverManager
 from webdriver_manager.core.driver_cache import DriverCacheManager
-from webdriver_manager.core.logger import log
-from webdriver_manager.core.os_manager import ChromeType, OSType, OperationSystemManager
+from webdriver_manager.core.os_manager import ChromeType, OperationSystemManager
+from webdriver_manager.drivers.chrome import CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL, \
+    CHROME_FOR_TESTING_LATEST_VERSIONS_PER_MILESTONE_URL, CHROME_FOR_TESTING_KNOWN_GOOD_VERSIONS_URL
 
 
 @pytest.mark.filterwarnings("ignore:Unverified HTTPS request:urllib3.exceptions.InsecureRequestWarning")
@@ -63,3 +65,122 @@ def test_can_get_brave_for_win(os_type):
                                os_system_manager=OperationSystemManager(os_type),
                                chrome_type=ChromeType.BRAVE).install()
     assert os.path.exists(path)
+
+
+def test_brave_latest_release_version_falls_back_to_latest_milestone_when_build_is_missing():
+    driver, http_client = chrome_driver_for(
+        browser_version="120.0.6099.71",
+        chrome_type=ChromeType.BRAVE,
+        responses={
+            CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL: {
+                "builds": {},
+            },
+            CHROME_FOR_TESTING_LATEST_VERSIONS_PER_MILESTONE_URL: {
+                "milestones": {
+                    "120": {
+                        "version": "120.0.6099.109",
+                    },
+                },
+            },
+        },
+    )
+
+    assert driver.get_latest_release_version() == "120.0.6099.109"
+
+    assert http_client.requested_urls == [
+        CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL,
+        CHROME_FOR_TESTING_LATEST_VERSIONS_PER_MILESTONE_URL,
+    ]
+
+
+def test_brave_latest_release_version_raises_readable_error_when_no_build_and_no_milestone_exist():
+    driver, http_client = chrome_driver_for(
+        browser_version="120.0.9999.1",
+        chrome_type=ChromeType.BRAVE,
+        responses={
+            CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL: {
+                "builds": {},
+            },
+            CHROME_FOR_TESTING_LATEST_VERSIONS_PER_MILESTONE_URL: {
+                "milestones": {},
+            },
+        },
+    )
+
+    with pytest.raises(ValueError) as error:
+        driver.get_latest_release_version()
+
+    message = str(error.value)
+
+    assert "Could not find a compatible chromedriver version" in message
+    assert f"{ChromeType.BRAVE} 120.0.9999.1" in message
+    assert CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL in message
+    assert CHROME_FOR_TESTING_LATEST_VERSIONS_PER_MILESTONE_URL in message
+
+    assert http_client.requested_urls == [
+        CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL,
+        CHROME_FOR_TESTING_LATEST_VERSIONS_PER_MILESTONE_URL,
+    ]
+
+
+@pytest.mark.parametrize(
+    ("platform", "expected_url"),
+    [
+        (
+            "mac-arm64",
+            "https://storage.googleapis.com/chrome-for-testing-public/"
+            "131.0.6778.264/mac-arm64/chromedriver-mac-arm64.zip",
+        ),
+        (
+            "mac-x64",
+            "https://storage.googleapis.com/chrome-for-testing-public/"
+            "131.0.6778.264/mac-x64/chromedriver-mac-x64.zip",
+        ),
+    ],
+)
+def test_brave_115_plus_uses_chrome_for_testing_macos_download_url_after_milestone_fallback(
+    platform,
+    expected_url,
+):
+    driver, http_client = chrome_driver_for(
+        browser_version="131.0.6778.1",
+        chrome_type=ChromeType.BRAVE,
+        responses={
+            CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL: {
+                "builds": {},
+            },
+            CHROME_FOR_TESTING_LATEST_VERSIONS_PER_MILESTONE_URL: {
+                "milestones": {
+                    "131": {
+                        "version": "131.0.6778.264",
+                    },
+                },
+            },
+            CHROME_FOR_TESTING_KNOWN_GOOD_VERSIONS_URL: {
+                "versions": [
+                    {
+                        "version": "131.0.6778.264",
+                        "downloads": {
+                            "chromedriver": [
+                                {
+                                    "platform": platform,
+                                    "url": expected_url,
+                                },
+                            ],
+                        },
+                    },
+                ],
+            },
+        },
+    )
+
+    driver_version = driver.get_latest_release_version()
+
+    assert driver_version == "131.0.6778.264"
+    assert driver.get_url_for_version_and_platform(driver_version, platform) == expected_url
+
+    assert http_client.requested_urls == [
+        CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL,
+        CHROME_FOR_TESTING_LATEST_VERSIONS_PER_MILESTONE_URL,
+        CHROME_FOR_TESTING_KNOWN_GOOD_VERSIONS_URL,
+    ]

--- a/tests/test_chromium_driver.py
+++ b/tests/test_chromium_driver.py
@@ -2,9 +2,15 @@ import os
 
 import pytest
 
+from tests.helper import chrome_driver_for
 from webdriver_manager.chrome import ChromeDriverManager
 from webdriver_manager.core.driver_cache import DriverCacheManager
 from webdriver_manager.core.os_manager import ChromeType, OperationSystemManager
+from webdriver_manager.drivers.chrome import (
+    CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL,
+    CHROME_FOR_TESTING_LATEST_VERSIONS_PER_MILESTONE_URL,
+    CHROME_FOR_TESTING_KNOWN_GOOD_VERSIONS_URL,
+)
 
 
 @pytest.mark.filterwarnings("ignore:Unverified HTTPS request:urllib3.exceptions.InsecureRequestWarning")
@@ -43,9 +49,324 @@ def test_chromium_manager_with_wrong_version():
     assert "There is no such driver by url" in ex.value.args[0]
 
 
+def test_chromium_latest_release_version_uses_latest_patch_version_per_build():
+    driver, http_client = chrome_driver_for(
+        browser_version="120.0.6099.71",
+        responses={
+            CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL: {
+                "builds": {
+                    "120.0.6099": {
+                        "version": "120.0.6099.109",
+                    },
+                },
+            },
+        },
+    )
+
+    assert driver.get_latest_release_version() == "120.0.6099.109"
+    assert http_client.requested_urls == [
+        CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL,
+    ]
+
+
+def test_chromium_latest_release_version_falls_back_to_latest_milestone_when_build_is_missing():
+    driver, http_client = chrome_driver_for(
+        browser_version="120.0.6099.71",
+        responses={
+            CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL: {
+                "builds": {},
+            },
+            CHROME_FOR_TESTING_LATEST_VERSIONS_PER_MILESTONE_URL: {
+                "milestones": {
+                    "120": {
+                        "version": "120.0.6099.109",
+                    },
+                },
+            },
+        },
+    )
+
+    assert driver.get_latest_release_version() == "120.0.6099.109"
+    assert http_client.requested_urls == [
+        CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL,
+        CHROME_FOR_TESTING_LATEST_VERSIONS_PER_MILESTONE_URL,
+    ]
+
+
+def test_chromium_latest_release_version_raises_readable_error_when_build_has_no_version():
+    driver, http_client = chrome_driver_for(
+        browser_version="120.0.6099.71",
+        responses={
+            CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL: {
+                "builds": {
+                    "120.0.6099": {},
+                },
+            },
+        },
+    )
+
+    with pytest.raises(ValueError) as error:
+        driver.get_latest_release_version()
+
+    message = str(error.value)
+
+    assert "Could not find a compatible chromedriver version" in message
+    assert "chromium 120.0.6099.71" in message
+    assert CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL in message
+    assert "entry for build 120.0.6099" in message
+    assert "does not contain a driver version" in message
+    assert http_client.requested_urls == [
+        CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL,
+    ]
+
+
+def test_chromium_latest_release_version_raises_readable_error_when_no_build_and_no_milestone_exist():
+    driver, http_client = chrome_driver_for(
+        browser_version="120.0.9999.1",
+        responses={
+            CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL: {
+                "builds": {},
+            },
+            CHROME_FOR_TESTING_LATEST_VERSIONS_PER_MILESTONE_URL: {
+                "milestones": {},
+            },
+        },
+    )
+
+    with pytest.raises(ValueError) as error:
+        driver.get_latest_release_version()
+
+    message = str(error.value)
+
+    assert "Could not find a compatible chromedriver version" in message
+    assert "chromium 120.0.9999.1" in message
+    assert CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL in message
+    assert CHROME_FOR_TESTING_LATEST_VERSIONS_PER_MILESTONE_URL in message
+    assert "No entry for build 120.0.9999" in message
+    assert "no entry for milestone 120" in message
+    assert http_client.requested_urls == [
+        CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL,
+        CHROME_FOR_TESTING_LATEST_VERSIONS_PER_MILESTONE_URL,
+    ]
+
+
+def test_chromium_latest_release_version_raises_readable_error_when_milestone_has_no_version():
+    driver, http_client = chrome_driver_for(
+        browser_version="120.0.9999.1",
+        responses={
+            CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL: {
+                "builds": {},
+            },
+            CHROME_FOR_TESTING_LATEST_VERSIONS_PER_MILESTONE_URL: {
+                "milestones": {
+                    "120": {},
+                },
+            },
+        },
+    )
+
+    with pytest.raises(ValueError) as error:
+        driver.get_latest_release_version()
+
+    message = str(error.value)
+
+    assert "Could not find a compatible chromedriver version" in message
+    assert "chromium 120.0.9999.1" in message
+    assert CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL in message
+    assert CHROME_FOR_TESTING_LATEST_VERSIONS_PER_MILESTONE_URL in message
+    assert "entry for milestone 120" in message
+    assert "does not contain a driver version" in message
+    assert http_client.requested_urls == [
+        CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL,
+        CHROME_FOR_TESTING_LATEST_VERSIONS_PER_MILESTONE_URL,
+    ]
+
+
+def test_chromium_latest_release_version_raises_readable_error_when_cft_metadata_is_not_json():
+    driver, http_client = chrome_driver_for(
+        browser_version="120.0.6099.71",
+        responses={
+            CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL: "not json",
+        },
+    )
+
+    with pytest.raises(ValueError) as error:
+        driver.get_latest_release_version()
+
+    message = str(error.value)
+
+    assert "Could not parse Chrome for Testing metadata" in message
+    assert CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL in message
+    assert http_client.requested_urls == [
+        CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL,
+    ]
+
+
+def test_chrome_115_plus_uses_chrome_for_testing_download_url_after_milestone_fallback():
+    driver, http_client = chrome_driver_for(
+        browser_version="131.0.6778.1",
+        responses={
+            CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL: {
+                "builds": {},
+            },
+            CHROME_FOR_TESTING_LATEST_VERSIONS_PER_MILESTONE_URL: {
+                "milestones": {
+                    "131": {
+                        "version": "131.0.6778.264",
+                    },
+                },
+            },
+            CHROME_FOR_TESTING_KNOWN_GOOD_VERSIONS_URL: {
+                "versions": [
+                    {
+                        "version": "131.0.6778.264",
+                        "downloads": {
+                            "chromedriver": [
+                                {
+                                    "platform": "win64",
+                                    "url": (
+                                        "https://storage.googleapis.com/"
+                                        "chrome-for-testing-public/"
+                                        "131.0.6778.264/"
+                                        "win64/"
+                                        "chromedriver-win64.zip"
+                                    ),
+                                },
+                            ],
+                        },
+                    },
+                ],
+            },
+        },
+    )
+
+    driver_version = driver.get_latest_release_version()
+
+    assert driver_version == "131.0.6778.264"
+
+    assert (
+        driver.get_url_for_version_and_platform(driver_version, "win64")
+        == "https://storage.googleapis.com/"
+           "chrome-for-testing-public/"
+           "131.0.6778.264/"
+           "win64/"
+           "chromedriver-win64.zip"
+    )
+
+    assert http_client.requested_urls == [
+        CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL,
+        CHROME_FOR_TESTING_LATEST_VERSIONS_PER_MILESTONE_URL,
+        CHROME_FOR_TESTING_KNOWN_GOOD_VERSIONS_URL,
+    ]
+
+
 @pytest.mark.parametrize('os_type', ['win32', 'win64'])
 def test_can_get_chromium_for_win(os_type):
     path = ChromeDriverManager(driver_version="115.0.5763.0",
                                os_system_manager=OperationSystemManager(os_type=os_type),
                                chrome_type=ChromeType.CHROMIUM).install()
     assert os.path.exists(path)
+
+
+def test_chromium_latest_release_version_does_not_request_milestone_when_build_exists():
+    driver, http_client = chrome_driver_for(
+        browser_version="120.0.6099.71",
+        responses={
+            CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL: {
+                "builds": {
+                    "120.0.6099": {
+                        "version": "120.0.6099.109",
+                    },
+                },
+            },
+        },
+    )
+
+    assert driver.get_latest_release_version() == "120.0.6099.109"
+
+    assert http_client.requested_urls == [
+        CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL,
+    ]
+
+
+def test_chromium_115_plus_resolves_driver_version_from_milestone_when_build_metadata_is_missing():
+    driver, http_client = chrome_driver_for(
+        browser_version="115.0.5790.99",
+        responses={
+            CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL: {
+                "builds": {},
+            },
+            CHROME_FOR_TESTING_LATEST_VERSIONS_PER_MILESTONE_URL: {
+                "milestones": {
+                    "115": {
+                        "version": "115.0.5790.170",
+                    },
+                },
+            },
+        },
+    )
+
+    assert driver.get_latest_release_version() == "115.0.5790.170"
+
+    assert http_client.requested_urls == [
+        CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL,
+        CHROME_FOR_TESTING_LATEST_VERSIONS_PER_MILESTONE_URL,
+    ]
+
+
+def test_chrome_115_plus_uses_chrome_for_testing_macos_download_url_after_milestone_fallback():
+    driver, http_client = chrome_driver_for(
+        browser_version="131.0.6778.1",
+        responses={
+            CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL: {
+                "builds": {},
+            },
+            CHROME_FOR_TESTING_LATEST_VERSIONS_PER_MILESTONE_URL: {
+                "milestones": {
+                    "131": {
+                        "version": "131.0.6778.264",
+                    },
+                },
+            },
+            CHROME_FOR_TESTING_KNOWN_GOOD_VERSIONS_URL: {
+                "versions": [
+                    {
+                        "version": "131.0.6778.264",
+                        "downloads": {
+                            "chromedriver": [
+                                {
+                                    "platform": "mac-arm64",
+                                    "url": (
+                                        "https://storage.googleapis.com/"
+                                        "chrome-for-testing-public/"
+                                        "131.0.6778.264/"
+                                        "mac-arm64/"
+                                        "chromedriver-mac-arm64.zip"
+                                    ),
+                                },
+                            ],
+                        },
+                    },
+                ],
+            },
+        },
+    )
+
+    driver_version = driver.get_latest_release_version()
+
+    assert driver_version == "131.0.6778.264"
+
+    assert (
+        driver.get_url_for_version_and_platform(driver_version, "mac-arm64")
+        == "https://storage.googleapis.com/"
+           "chrome-for-testing-public/"
+           "131.0.6778.264/"
+           "mac-arm64/"
+           "chromedriver-mac-arm64.zip"
+    )
+
+    assert http_client.requested_urls == [
+        CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL,
+        CHROME_FOR_TESTING_LATEST_VERSIONS_PER_MILESTONE_URL,
+        CHROME_FOR_TESTING_KNOWN_GOOD_VERSIONS_URL,
+    ]

--- a/webdriver_manager/drivers/chrome.py
+++ b/webdriver_manager/drivers/chrome.py
@@ -3,7 +3,18 @@ from packaging import version
 from webdriver_manager.core.driver import Driver
 from webdriver_manager.core.logger import log
 from webdriver_manager.core.os_manager import ChromeType
+
 import json
+
+CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL = (
+    "https://googlechromelabs.github.io/chrome-for-testing/latest-patch-versions-per-build.json"
+)
+CHROME_FOR_TESTING_LATEST_VERSIONS_PER_MILESTONE_URL = (
+    "https://googlechromelabs.github.io/chrome-for-testing/latest-versions-per-milestone.json"
+)
+CHROME_FOR_TESTING_KNOWN_GOOD_VERSIONS_URL = (
+    "https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json"
+)
 
 
 class ChromeDriver(Driver):
@@ -54,14 +65,12 @@ class ChromeDriver(Driver):
     def get_latest_release_version(self):
         determined_browser_version = self.get_browser_version_from_os()
         log(f"Get LATEST {self._name} version for {self._browser_type}")
+
         if determined_browser_version is not None and version.parse(determined_browser_version) >= version.parse("115"):
-            url = "https://googlechromelabs.github.io/chrome-for-testing/latest-patch-versions-per-build.json"
-            response = self._http_client.get(url)
-            response_dict = json.loads(response.text)
-            determined_browser_version = response_dict.get("builds").get(determined_browser_version).get("version")
-            return determined_browser_version
+            return self._latest_cft_version_for_browser_version(determined_browser_version)
+
         elif determined_browser_version is not None:
-            # Remove the build version (the last segment) from determined_browser_version for version < 113
+            # Remove the build version (the last segment) from determined_browser_version for version < 115
             determined_browser_version = ".".join(determined_browser_version.split(".")[:3])
             latest_release_url = f"{self._latest_release_url}_{determined_browser_version}"
         else:
@@ -69,6 +78,87 @@ class ChromeDriver(Driver):
 
         resp = self._http_client.get(url=latest_release_url)
         return resp.text.rstrip()
+
+    def _latest_cft_version_for_browser_version(self, browser_version):
+        browser_build_version = ".".join(browser_version.split(".")[:3])
+        browser_milestone = browser_version.split(".")[0]
+
+        latest_patch_versions = self._get_cft_json(
+            CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL
+        )
+        builds = latest_patch_versions.get("builds") or {}
+        build = builds.get(browser_build_version)
+
+        if build is not None:
+            chromedriver_version = build.get("version")
+            if chromedriver_version:
+                return chromedriver_version
+
+            self._raise_missing_chromedriver_version(
+                browser_version=browser_version,
+                checked_urls=[CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL],
+                details=(
+                    f"Chrome for Testing metadata contains an entry for build "
+                    f"{browser_build_version}, but it does not contain a driver version."
+                ),
+            )
+
+        latest_milestone_versions = self._get_cft_json(
+            CHROME_FOR_TESTING_LATEST_VERSIONS_PER_MILESTONE_URL
+        )
+        milestones = latest_milestone_versions.get("milestones") or {}
+        milestone = milestones.get(browser_milestone)
+
+        if milestone is not None:
+            chromedriver_version = milestone.get("version")
+            if chromedriver_version:
+                return chromedriver_version
+
+            self._raise_missing_chromedriver_version(
+                browser_version=browser_version,
+                checked_urls=[
+                    CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL,
+                    CHROME_FOR_TESTING_LATEST_VERSIONS_PER_MILESTONE_URL,
+                ],
+                details=(
+                    f"Chrome for Testing metadata contains an entry for milestone "
+                    f"{browser_milestone}, but it does not contain a driver version."
+                ),
+            )
+
+        self._raise_missing_chromedriver_version(
+            browser_version=browser_version,
+            checked_urls=[
+                CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL,
+                CHROME_FOR_TESTING_LATEST_VERSIONS_PER_MILESTONE_URL,
+            ],
+            details=(
+                f"No entry for build {browser_build_version} and no entry for "
+                f"milestone {browser_milestone} were found."
+            ),
+        )
+
+    def _get_cft_json(self, url):
+        response = self._http_client.get(url)
+
+        try:
+            return json.loads(response.text)
+        except ValueError as error:
+            raise ValueError(
+                f"Could not parse Chrome for Testing metadata from {url}."
+            ) from error
+
+    def _raise_missing_chromedriver_version(self, browser_version, checked_urls, details):
+        raise ValueError(
+            f"Could not find a compatible {self._name} version for "
+            f"{self._browser_type} {browser_version}. "
+            f"Checked Chrome for Testing endpoints: {', '.join(checked_urls)}. "
+            f"Possible reasons: your browser was updated before the matching driver "
+            f"was published, the browser version is too new, or this version is no "
+            f"longer available in Chrome for Testing. "
+            f"Try pinning browser/driver versions or installing a supported "
+            f"Chrome/Chromium version. Details: {details}"
+        )
 
     def get_url_for_version_and_platform(self, browser_version, platform):
         url = "https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json"


### PR DESCRIPTION
## Summary

Fix Chrome for Testing (CfT) version resolution for Chromium-based browsers when exact build metadata is missing.

The previous implementation assumed that the detected browser build always exists in:

- `latest-patch-versions-per-build.json`

and failed with internal `NoneType` errors when the build was missing.

This patch:

- adds fallback from build-based lookup to milestone-based lookup;
- improves readable error handling for unresolved CfT versions;
- adds regression coverage for Chromium and Brave;
- adds regression coverage for Chrome for Testing download URL resolution on Windows and macOS;
- verifies request order across the CfT resolution pipeline.

## Changes

- Added fallback from:
  - `latest-patch-versions-per-build.json`
  - to `latest-versions-per-milestone.json`
- Replaced internal `NoneType` crashes with actionable `ValueError` messages.
- Added malformed CfT metadata handling.
- Added regression coverage for:
  - missing build metadata;
  - missing milestone metadata;
  - malformed JSON metadata;
  - Chromium fallback resolution;
  - Brave fallback resolution;
  - Windows CfT download URLs;
  - macOS CfT download URLs;
  - request ordering through CfT endpoints.

## Issues

Closes #637.
Closes #642.
Closes #669.
Closes #691.