### PR TITLE
Run Linux tests with explicit xvfb-run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,8 +69,8 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install software-properties-common apt-transport-https wget curl
-          
+          sudo apt-get install -y software-properties-common apt-transport-https wget curl xvfb
+
           wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
           sudo dpkg -i google-chrome-stable_current_amd64.deb
           
@@ -124,10 +124,14 @@ jobs:
         if: runner.os == 'Linux'
         env:
           WDM_LOG: ${{ matrix.wdm-log }}
-        uses: coactions/setup-xvfb@v1
-        with:
-          run: |
-            pipenv run py.test -sv --cov-config .coveragerc --cov-report xml --cov-report term:skip-covered --cov=webdriver_manager --tb=short tests/
+        run: |
+          xvfb-run -a pipenv run py.test -sv \
+            --cov-config .coveragerc \
+            --cov-report xml \
+            --cov-report term:skip-covered \
+            --cov=webdriver_manager \
+            --tb=short \
+            tests/
 
       - name: Run tests on Windows (without xvfb)
         if: runner.os == 'Windows'
@@ -153,7 +157,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.7' ]
+        python-version: [ '3.9' ]
         selenium-version: [ '3.141.0' ]
         os: [ ubuntu-latest ]
 
@@ -171,6 +175,12 @@ jobs:
           sudo apt autoremove && sudo apt autoclean -y
           sudo apt clean
 
+      - name: Install Xvfb
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb
+
       - name: Install Python dependencies
         run: |
           python -m pip install -U pip wheel
@@ -180,10 +190,14 @@ jobs:
 
       - name: Run tests on Linux (with xvfb)
         if: runner.os == 'Linux'
-        uses: coactions/setup-xvfb@v1
-        with:
-          run: |
-            pipenv run py.test -sv --cov-config .coveragerc --cov-report xml --cov-report term:skip-covered --cov=webdriver_manager --tb=short tests_negative/
+        run: |
+          xvfb-run -a pipenv run py.test -sv \
+            --cov-config .coveragerc \
+            --cov-report xml \
+            --cov-report term:skip-covered \
+            --cov=webdriver_manager \
+            --tb=short \
+            tests_negative/
 
       - name: Codecov Upload
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
## Summary

Replace `coactions/setup-xvfb@v1` with explicit `xvfb-run`.

The previous setup could fail during cleanup because the action attempted to run a missing `dist/cleanup.sh` script. Running `xvfb-run -a` directly keeps the Linux browser tests under Xvfb without relying on the action cleanup hook.