### PR TITLE
Fix PermissionError in Docker by adding safe fallback for default cache path (#636)

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,10 @@ import os
 os.environ['WDM_LOCAL'] = '1'
 ```
 
+For Docker/CI environments, this is recommended when home-directory permissions are restricted.
+You can also pass a custom writable cache location via `DriverCacheManager(root_dir=...)`.
+Additionally, webdriver-manager includes a fallback to the system temp directory when home resolves to `/` or is unresolved (fix for issue `#636`).
+
 ### `WDM_SSL_VERIFY`
 SSL verification can be disabled for downloading webdriver binaries in case when you have troubles with SSL Certificates or SSL Certificate Chain. Just set the environment variable `WDM_SSL_VERIFY` to `"0"`.
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,0 @@
-[pytest]
-console_output_style = progress
-log_cli = 1
-addopts =
-    -W ignore::DeprecationWarning -W ignore::urllib3.exceptions.InsecureRequestWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+console_output_style = progress
+log_cli = 1
+addopts =
+    -W ignore::DeprecationWarning -W ignore::urllib3.exceptions.InsecureRequestWarning

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,19 @@
+import tempfile
+
+from webdriver_manager.core.constants import ROOT_FOLDER_NAME, get_default_user_home_cache_path
+
+
+def test_default_user_home_cache_path_falls_back_to_temp_if_home_is_root(monkeypatch):
+    monkeypatch.setattr("os.path.expanduser", lambda _path: "/")
+
+    cache_path = get_default_user_home_cache_path()
+
+    assert cache_path == f"{tempfile.gettempdir()}/{ROOT_FOLDER_NAME}"
+
+
+def test_default_user_home_cache_path_falls_back_to_temp_if_home_is_unresolved(monkeypatch):
+    monkeypatch.setattr("os.path.expanduser", lambda _path: "~")
+
+    cache_path = get_default_user_home_cache_path()
+
+    assert cache_path == f"{tempfile.gettempdir()}/{ROOT_FOLDER_NAME}"

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,4 +1,5 @@
 import tempfile
+import os
 
 from webdriver_manager.core.constants import ROOT_FOLDER_NAME, get_default_user_home_cache_path
 
@@ -8,7 +9,7 @@ def test_default_user_home_cache_path_falls_back_to_temp_if_home_is_root(monkeyp
 
     cache_path = get_default_user_home_cache_path()
 
-    assert cache_path == f"{tempfile.gettempdir()}/{ROOT_FOLDER_NAME}"
+    assert cache_path == os.path.join(tempfile.gettempdir(), ROOT_FOLDER_NAME)
 
 
 def test_default_user_home_cache_path_falls_back_to_temp_if_home_is_unresolved(monkeypatch):
@@ -16,4 +17,4 @@ def test_default_user_home_cache_path_falls_back_to_temp_if_home_is_unresolved(m
 
     cache_path = get_default_user_home_cache_path()
 
-    assert cache_path == f"{tempfile.gettempdir()}/{ROOT_FOLDER_NAME}"
+    assert cache_path == os.path.join(tempfile.gettempdir(), ROOT_FOLDER_NAME)

--- a/tests/test_driver_cache_manager.py
+++ b/tests/test_driver_cache_manager.py
@@ -1,0 +1,94 @@
+import json
+import datetime
+
+import requests
+
+from webdriver_manager.core.driver_cache import DriverCacheManager
+from webdriver_manager.firefox import GeckoDriverManager
+
+
+class OSMock:
+    def get_os_type(self):
+        return "linux64"
+
+    def get_browser_version_from_os(self, _browser_type):
+        return "122.0"
+
+
+class DriverMock:
+    def __init__(self):
+        self.version_lookup_calls = 0
+
+    def get_name(self):
+        return "geckodriver"
+
+    def get_browser_type(self):
+        return "firefox"
+
+    def get_browser_version_from_os(self):
+        return "122.0"
+
+    def get_driver_version_to_download(self):
+        self.version_lookup_calls += 1
+        raise RuntimeError("remote lookup should not be called when cache already has matching browser version")
+
+
+def test_find_driver_uses_cached_entry_without_remote_version_lookup(tmp_path):
+    cache = DriverCacheManager(root_dir=str(tmp_path), os_system_manager=OSMock())
+    driver = DriverMock()
+
+    driver_dir = tmp_path / ".wdm" / "drivers" / "geckodriver" / "linux64" / "v0.34.0"
+    driver_dir.mkdir(parents=True, exist_ok=True)
+    binary_path = driver_dir / "geckodriver"
+    binary_path.write_text("bin")
+
+    metadata_path = tmp_path / ".wdm" / "drivers.json"
+    metadata = {
+        "linux64_geckodriver_v0.34.0_for_122.0": {
+            "timestamp": datetime.date.today().strftime("%d/%m/%Y"),
+            "binary_path": str(binary_path),
+        }
+    }
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    metadata_path.write_text(json.dumps(metadata))
+
+    resolved_path = cache.find_driver(driver)
+
+    assert resolved_path == str(binary_path)
+    assert driver.version_lookup_calls == 0
+
+
+def test_gecko_manager_install_uses_cache_without_network(monkeypatch, tmp_path):
+    os_manager = OSMock()
+    cache = DriverCacheManager(root_dir=str(tmp_path), os_system_manager=os_manager)
+
+    driver_dir = tmp_path / ".wdm" / "drivers" / "geckodriver" / "linux64" / "v0.34.0"
+    driver_dir.mkdir(parents=True, exist_ok=True)
+    binary_path = driver_dir / "geckodriver"
+    binary_path.write_text("bin")
+
+    metadata_path = tmp_path / ".wdm" / "drivers.json"
+    metadata = {
+        "linux64_geckodriver_v0.34.0_for_122.0": {
+            "timestamp": datetime.date.today().strftime("%d/%m/%Y"),
+            "binary_path": str(binary_path),
+        }
+    }
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    metadata_path.write_text(json.dumps(metadata))
+
+    network_calls = {"count": 0}
+
+    def fail_requests_get(*args, **kwargs):
+        network_calls["count"] += 1
+        raise AssertionError("Network should not be called when cache contains a valid driver")
+
+    monkeypatch.setattr(requests, "get", fail_requests_get)
+
+    resolved_path = GeckoDriverManager(
+        cache_manager=cache,
+        os_system_manager=os_manager,
+    ).install()
+
+    assert resolved_path == str(binary_path)
+    assert network_calls["count"] == 0

--- a/tests/test_firefox_arch_detection.py
+++ b/tests/test_firefox_arch_detection.py
@@ -1,0 +1,29 @@
+from webdriver_manager.firefox import GeckoDriverManager
+
+
+class LinuxAarch64OsManagerMock:
+    def get_os_type(self):
+        return "linux64"
+
+    def get_os_name(self):
+        return "linux"
+
+    def is_arch(self):
+        return False
+
+    def get_os_architecture(self):
+        return 64
+
+    @staticmethod
+    def is_mac_os(_):
+        return False
+
+
+def test_gecko_manager_prefers_linux_aarch64_when_platform_reports_arm64(monkeypatch):
+    monkeypatch.setattr("webdriver_manager.firefox.platform.machine", lambda: "aarch64")
+    monkeypatch.setattr("webdriver_manager.firefox.platform.processor", lambda: "aarch64")
+
+    manager = GeckoDriverManager(os_system_manager=LinuxAarch64OsManagerMock())
+
+    assert manager.get_os_type() == "linux-aarch64"
+

--- a/webdriver_manager/core/constants.py
+++ b/webdriver_manager/core/constants.py
@@ -8,7 +8,7 @@ DEFAULT_PROJECT_ROOT_CACHE_PATH = os.path.join(sys.path[0], ROOT_FOLDER_NAME)
 
 def get_default_user_home_cache_path():
     home = os.path.expanduser("~")
-    if not home or home == os.path.sep or home.startswith("~"):
+    if not home or home in (os.path.sep, "/") or home.startswith("~"):
         home = tempfile.gettempdir()
     return os.path.join(home, ROOT_FOLDER_NAME)
 

--- a/webdriver_manager/core/constants.py
+++ b/webdriver_manager/core/constants.py
@@ -1,7 +1,16 @@
 import os
 import sys
+import tempfile
 
 ROOT_FOLDER_NAME = ".wdm"
 DEFAULT_PROJECT_ROOT_CACHE_PATH = os.path.join(sys.path[0], ROOT_FOLDER_NAME)
-DEFAULT_USER_HOME_CACHE_PATH = os.path.join(
-    os.path.expanduser("~"), ROOT_FOLDER_NAME)
+
+
+def get_default_user_home_cache_path():
+    home = os.path.expanduser("~")
+    if not home or home == os.path.sep or home.startswith("~"):
+        home = tempfile.gettempdir()
+    return os.path.join(home, ROOT_FOLDER_NAME)
+
+
+DEFAULT_USER_HOME_CACHE_PATH = get_default_user_home_cache_path()


### PR DESCRIPTION
This PR fixes issue #636 where `ChromeDriverManager().install()` could fail with:

`PermissionError: [Errno 13] Permission denied: '/.wdm'`

Root cause:
- Default cache path was built from `os.path.expanduser("~")`.
- In some Docker/non-root environments, this resolves to `/` (or stays unresolved), producing `/.wdm`, which is not writable.

What changed:
- Added `get_default_user_home_cache_path()` in `core/constants.py`.
- If home is `/`, empty, or unresolved (`"~"`), fallback is `tempfile.gettempdir()/.wdm`.
- `DEFAULT_USER_HOME_CACHE_PATH` now uses that helper.

Tests:
- Added unit tests covering both fallback scenarios.
- Existing Chrome cache test still passes.
