### PR TITLE
Fix Windows ChromeDriver platform selection for Chrome 115+ (issue #686)

### DIFF
--- a/tests/test_chrome_driver.py
+++ b/tests/test_chrome_driver.py
@@ -154,3 +154,58 @@ def test_chrome_118_resolves_cft_driver_version_and_download_url():
     assert "chromedriver.storage.googleapis.com" not in driver.get_driver_download_url("win32")
     assert CHROME_FOR_TESTING_LATEST_PATCH_VERSIONS_PER_BUILD_URL in http_client.requested_urls
     assert CHROME_FOR_TESTING_KNOWN_GOOD_VERSIONS_URL in http_client.requested_urls
+
+
+def test_chrome_115_plus_prefers_win64_download_when_available():
+    expected_url = (
+        "https://storage.googleapis.com/chrome-for-testing-public/"
+        "131.0.6778.264/win64/chromedriver-win64.zip"
+    )
+    driver, _ = chrome_driver_for(
+        browser_version="131.0.6778.70",
+        chrome_type=ChromeType.GOOGLE,
+        responses={
+            CHROME_FOR_TESTING_KNOWN_GOOD_VERSIONS_URL: {
+                "versions": [
+                    {
+                        "version": "131.0.6778.264",
+                        "downloads": {
+                            "chromedriver": [
+                                {"platform": "win32", "url": "https://example/win32.zip"},
+                                {"platform": "win64", "url": expected_url},
+                            ],
+                        },
+                    },
+                ],
+            },
+        },
+    )
+
+    assert driver.get_url_for_version_and_platform("131.0.6778.264", "win64") == expected_url
+
+
+def test_chrome_115_plus_falls_back_to_win32_when_win64_is_unavailable():
+    expected_url = (
+        "https://storage.googleapis.com/chrome-for-testing-public/"
+        "131.0.6778.264/win32/chromedriver-win32.zip"
+    )
+    driver, _ = chrome_driver_for(
+        browser_version="131.0.6778.70",
+        chrome_type=ChromeType.GOOGLE,
+        responses={
+            CHROME_FOR_TESTING_KNOWN_GOOD_VERSIONS_URL: {
+                "versions": [
+                    {
+                        "version": "131.0.6778.264",
+                        "downloads": {
+                            "chromedriver": [
+                                {"platform": "win32", "url": expected_url},
+                            ],
+                        },
+                    },
+                ],
+            },
+        },
+    )
+
+    assert driver.get_url_for_version_and_platform("131.0.6778.264", "win64") == expected_url

--- a/webdriver_manager/chrome.py
+++ b/webdriver_manager/chrome.py
@@ -44,7 +44,7 @@ class ChromeDriverManager(DriverManager):
     def get_os_type(self):
         os_type = super().get_os_type()
         if "win" in os_type:
-            return "win32"
+            return "win64" if self._os_system_manager.get_os_architecture() == 64 else "win32"
 
         if not self._os_system_manager.is_mac_os(os_type):
             return os_type

--- a/webdriver_manager/drivers/chrome.py
+++ b/webdriver_manager/drivers/chrome.py
@@ -176,6 +176,10 @@ class ChromeDriver(Driver):
                 for d in downloads:
                     if d["platform"] == platform:
                         return d["url"]
+                if platform == "win64":
+                    for d in downloads:
+                        if d["platform"] == "win32":
+                            return d["url"]
         else:
             for v in versions:
                 if v["version"] == browser_version:


### PR DESCRIPTION
This PR addresses issue #686 by improving Windows platform selection for ChromeDriver downloads.

What was happening:
- `ChromeDriverManager.get_os_type()` always returned `win32` on Windows, even on 64-bit systems.
- For Chrome 115+ (Chrome for Testing metadata), this could force downloading `chromedriver-win32.zip` on x64 machines.

What changed:
- `webdriver_manager/chrome.py`:
  - On Windows, return `win64` for 64-bit OS and `win32` for 32-bit OS.
- `webdriver_manager/drivers/chrome.py`:
  - For Chrome 115+ metadata resolution, if `win64` artifact is unavailable for a version, fallback to `win32` to preserve compatibility.

Tests added:
- `test_chrome_115_plus_prefers_win64_download_when_available`
- `test_chrome_115_plus_falls_back_to_win32_when_win64_is_unavailable`

Validation:
- Targeted tests passed: `6 passed` including new tests and Windows OS matrix resolver test.

Files changed:
- [chrome.py](/Users/kot/GitHubProjects/webdriver_manager/webdriver_manager/chrome.py)
- [chrome.py](/Users/kot/GitHubProjects/webdriver_manager/webdriver_manager/drivers/chrome.py)
- [test_chrome_driver.py](/Users/kot/GitHubProjects/webdriver_manager/tests/test_chrome_driver.py)
