### PR TITLE
Add regression test for macOS Exec format error caused by THIRD_PARTY_NOTICES (#683)

### DIFF
--- a/tests/test_driver_cache_binary_selection.py
+++ b/tests/test_driver_cache_binary_selection.py
@@ -1,0 +1,14 @@
+from webdriver_manager.core.driver_cache import DriverCacheManager
+
+
+def test_get_binary_skips_third_party_notices_for_chromedriver(tmp_path):
+    cache = DriverCacheManager(root_dir=str(tmp_path))
+    files = [
+        "chromedriver-mac-arm64/THIRD_PARTY_NOTICES.chromedriver",
+        "chromedriver-mac-arm64/LICENSE.chromedriver",
+        "chromedriver-mac-arm64/chromedriver",
+    ]
+
+    binary = cache._DriverCacheManager__get_binary(files, "chromedriver")
+
+    assert binary == "chromedriver-mac-arm64/chromedriver"


### PR DESCRIPTION
This PR addresses issue #683 by locking in the binary selection behavior for ChromeDriver archives.

Issue context:
- On macOS, users could hit:
  `Exec format error: .../THIRD_PARTY_NOTICES.chromedriver`
- This happens when a non-executable file is selected instead of the actual `chromedriver` binary.

Current code status:
- `DriverCacheManager.__get_binary` already skips `LICENSE` and `THIRD_PARTY` entries.
- However, there was no regression test proving this behavior.

What this PR changes:
- Adds a unit test that simulates archive entries:
  - `THIRD_PARTY_NOTICES.chromedriver`
  - `LICENSE.chromedriver`
  - `chromedriver`
- Verifies the selected binary is the real executable path, not notice/license files.

File added:
- [test_driver_cache_binary_selection.py](/Users/kot/GitHubProjects/webdriver_manager/tests/test_driver_cache_binary_selection.py)

Validation:
- `./.venv/bin/pytest -q tests/test_driver_cache_binary_selection.py`
- Result: `1 passed`