### PR TITLE
Docs: clarify pip package name and Python import name (#660)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ With webdriver manager, you just need to do two simple steps:
 pip install webdriver-manager
 ```
 
+Note: package name is `webdriver-manager`, import name is `webdriver_manager`.
+
 #### Use with Chrome
 
 ```python


### PR DESCRIPTION
Added a small clarification in README installation section:

- `pip install webdriver-manager`
- `import webdriver_manager`

This avoids confusion around hyphen/underscore naming and helps users who run into install/import mismatch assumptions.

File changed:
- [README.md](/Users/kot/GitHubProjects/webdriver_manager/README.md)