### PR TITLE
Fix DEFAULT_PROJECT_ROOT_CACHE_PATH for PyInstaller/frozen apps (#694)

### DIFF
--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -2,6 +2,7 @@ import tempfile
 import os
 
 from webdriver_manager.core.constants import ROOT_FOLDER_NAME, get_default_user_home_cache_path
+from webdriver_manager.core.constants import get_default_project_root_cache_path
 
 
 def test_default_user_home_cache_path_falls_back_to_temp_if_home_is_root(monkeypatch):
@@ -18,3 +19,13 @@ def test_default_user_home_cache_path_falls_back_to_temp_if_home_is_unresolved(m
     cache_path = get_default_user_home_cache_path()
 
     assert cache_path == os.path.join(tempfile.gettempdir(), ROOT_FOLDER_NAME)
+
+
+def test_default_project_root_cache_path_uses_cwd_for_frozen_app(monkeypatch):
+    monkeypatch.setattr("sys.path", ["C:/app/base_library.zip"])
+    monkeypatch.setattr("sys.frozen", True, raising=False)
+    monkeypatch.setattr("os.getcwd", lambda: "C:/app/runtime")
+
+    cache_path = get_default_project_root_cache_path()
+
+    assert cache_path == os.path.join("C:/app/runtime", ROOT_FOLDER_NAME)

--- a/webdriver_manager/core/constants.py
+++ b/webdriver_manager/core/constants.py
@@ -3,7 +3,16 @@ import sys
 import tempfile
 
 ROOT_FOLDER_NAME = ".wdm"
-DEFAULT_PROJECT_ROOT_CACHE_PATH = os.path.join(sys.path[0], ROOT_FOLDER_NAME)
+
+
+def get_default_project_root_cache_path():
+    base_path = sys.path[0]
+    if getattr(sys, "frozen", False) or base_path.endswith(".zip"):
+        base_path = os.getcwd()
+    return os.path.join(base_path, ROOT_FOLDER_NAME)
+
+
+DEFAULT_PROJECT_ROOT_CACHE_PATH = get_default_project_root_cache_path()
 
 
 def get_default_user_home_cache_path():


### PR DESCRIPTION
This PR fixes issue #694.

Problem:
`DEFAULT_PROJECT_ROOT_CACHE_PATH` used `sys.path[0]`, which points to `base_library.zip` in PyInstaller/frozen builds. That produces an invalid cache path and may crash compiled apps.

Solution:
- Added `get_default_project_root_cache_path()`.
- In frozen/zip runtime (`sys.frozen` or `sys.path[0].endswith(".zip")`), use `os.getcwd()` as base path.
- Keep existing behavior for normal Python runs.

Tests:
- Added regression test for frozen/zip scenario:
  `test_default_project_root_cache_path_uses_cwd_for_frozen_app`