### PR TITLE
Reduce repeated HTTP requests by caching resolved driver version (#656)

### DIFF
--- a/tests/test_driver_cache_request_dedup.py
+++ b/tests/test_driver_cache_request_dedup.py
@@ -1,0 +1,39 @@
+from webdriver_manager.core.driver_cache import DriverCacheManager
+
+
+class OSMock:
+    def get_os_type(self):
+        return "linux64"
+
+    def get_browser_version_from_os(self, _browser_type=None):
+        return "120.0.6099.71"
+
+
+class DriverMock:
+    def __init__(self):
+        self.version_calls = 0
+
+    def get_name(self):
+        return "chromedriver"
+
+    def get_browser_type(self):
+        return "google-chrome"
+
+    def get_browser_version_from_os(self):
+        return "120.0.6099.71"
+
+    def get_driver_version_to_download(self):
+        self.version_calls += 1
+        return "120.0.6099.109"
+
+
+def test_driver_version_lookup_is_cached_within_cache_manager(tmp_path):
+    cache = DriverCacheManager(root_dir=str(tmp_path), os_system_manager=OSMock())
+    driver = DriverMock()
+
+    cache.get_cache_key_driver_version(driver)
+    cache.get_cache_key_driver_version(driver)
+    cache._DriverCacheManager__get_path(driver)
+    cache._DriverCacheManager__get_metadata_key(driver)
+
+    assert driver.version_calls == 1

--- a/webdriver_manager/core/driver_cache.py
+++ b/webdriver_manager/core/driver_cache.py
@@ -194,7 +194,8 @@ class DriverCacheManager(object):
     def get_cache_key_driver_version(self, driver: Driver):
         if self._cache_key_driver_version:
             return self._cache_key_driver_version
-        return driver.get_driver_version_to_download()
+        self._cache_key_driver_version = driver.get_driver_version_to_download()
+        return self._cache_key_driver_version
 
     def __get_path(self, driver: Driver):
         if self._driver_binary_path is None:
@@ -202,6 +203,6 @@ class DriverCacheManager(object):
                 self._drivers_directory,
                 driver.get_name(),
                 self.get_os_type(),
-                driver.get_driver_version_to_download(),
+                self.get_cache_key_driver_version(driver),
             )
         return self._driver_binary_path


### PR DESCRIPTION
This PR addresses issue #656 (repeated HTTP requests during driver resolution).

Root cause:
`DriverCacheManager.get_cache_key_driver_version()` returned the resolved version but did not store it, so `get_driver_version_to_download()` could be called multiple times in one install flow.

Fix:
- Cache the resolved driver version in `_cache_key_driver_version`.
- Reuse that cached value in `__get_path()`.

Result:
Fewer repeated metadata requests (especially CfT endpoints) within a single manager/install flow.

Tests:
- Added `test_driver_version_lookup_is_cached_within_cache_manager` to ensure version lookup is performed once.