### PR TITLE
Fix Windows browser version detection by using PowerShell EncodedCommand (#625)

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,9 @@
 import pytest
 from requests import Response, Request
+import base64
 
 from webdriver_manager.core.http import HttpClient
+from webdriver_manager.core.utils import windows_browser_apps_to_cmd
 
 
 def test_validate_response_value_error_not_200_and_not_404():
@@ -39,3 +41,16 @@ def test_validate_response_value_error_404():
 
     expected_message = "There is no such driver by url https://example.com"
     assert str(excinfo.value) == expected_message
+
+
+def test_windows_browser_apps_to_cmd_uses_encoded_command(monkeypatch):
+    monkeypatch.setattr("webdriver_manager.core.utils.determine_powershell", lambda: "powershell")
+    expression = r'(Get-Item -Path "$env:PROGRAMFILES (x86)\Microsoft\Edge\Application\msedge.exe").VersionInfo.FileVersion'
+
+    cmd = windows_browser_apps_to_cmd(expression)
+
+    assert " -EncodedCommand " in cmd
+    encoded = cmd.split(" -EncodedCommand ", 1)[1]
+    script = base64.b64decode(encoded).decode("utf-16le")
+    assert expression in script
+    assert "$ErrorActionPreference='silentlycontinue';" in script

--- a/webdriver_manager/core/utils.py
+++ b/webdriver_manager/core/utils.py
@@ -2,6 +2,7 @@ import datetime
 import os
 import re
 import subprocess
+import base64
 
 
 def get_date_diff(date1, date2, date_format):
@@ -31,8 +32,10 @@ def windows_browser_apps_to_cmd(*apps: str) -> str:
     script = "$ErrorActionPreference='silentlycontinue'; " + " ".join(
         first_hit_template.format(expression=e) for e in apps
     )
-
-    return f'{powershell} -NoProfile "{script}"'
+    if not powershell:
+        return script
+    encoded_script = base64.b64encode(script.encode("utf-16le")).decode("ascii")
+    return f"{powershell} -NoProfile -EncodedCommand {encoded_script}"
 
 
 def read_version_from_cmd(cmd, pattern):


### PR DESCRIPTION
- Replaces fragile inline PowerShell quoting in `windows_browser_apps_to_cmd()` with `-EncodedCommand`.
- Prevents failures when expressions contain nested quotes and env variables (e.g. `$env:PROGRAMFILES (x86)` paths).
- Adds regression test to verify command encoding and script content.