### PR TITLE
Docs: clarify webdriver-manager scope for desktop browsers and Android/PyDroid guidance (#640)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ pip install webdriver-manager
 
 Note: package name is `webdriver-manager`, import name is `webdriver_manager`.
 
+#### Environment scope
+
+`webdriver-manager` manages **desktop browser drivers** (Windows/macOS/Linux desktop runtimes).
+It is not intended for Android/PyDroid local browser automation.
+
+For Android automation, use Appium (UiAutomator2) with Chrome/WebView on device/emulator.
+
 #### Use with Chrome
 
 ```python


### PR DESCRIPTION
This docs update clarifies runtime scope to reduce confusion in environments like PyDroid/Android.

Added a short “Environment scope” note in README:
- webdriver-manager manages desktop browser drivers (Windows/macOS/Linux desktop runtimes)
- Android/PyDroid local browser automation is out of scope
- For Android automation, use Appium (UiAutomator2) with Chrome/WebView

This addresses recurring confusion in issue #640.