### PR TITLE
Fix concurrent driver install race conditions causing BadZipFile/crashes (#700, #631)

### DIFF
--- a/tests/test_manager_concurrency.py
+++ b/tests/test_manager_concurrency.py
@@ -1,0 +1,66 @@
+from webdriver_manager.core.manager import DriverManager
+
+
+class FakeCacheManager:
+    def __init__(self):
+        self.find_calls = 0
+        self.saved = False
+
+    def find_driver(self, _driver):
+        self.find_calls += 1
+        if self.find_calls == 1:
+            return None
+        return "/tmp/cached/chromedriver"
+
+    def get_driver_lock_path(self, _driver_name, _os_type):
+        return "/tmp/wdm-test-lock"
+
+    def save_file_to_cache(self, _driver, _file):
+        self.saved = True
+        return "/tmp/new/chromedriver"
+
+
+class FakeDownloadManager:
+    def __init__(self):
+        self.download_calls = 0
+        self.http_client = None
+
+    def download_file(self, _url):
+        self.download_calls += 1
+        return object()
+
+
+class FakeDriver:
+    def get_name(self):
+        return "chromedriver"
+
+    def get_driver_download_url(self, _os_type):
+        return "https://example.invalid/chromedriver.zip"
+
+    def get_browser_type(self):
+        return "google-chrome"
+
+
+class FakeOSManager:
+    def get_os_type(self):
+        return "linux64"
+
+
+def test_get_driver_binary_path_rechecks_cache_after_lock(monkeypatch):
+    cache = FakeCacheManager()
+    downloader = FakeDownloadManager()
+    manager = DriverManager(
+        download_manager=downloader,
+        cache_manager=cache,
+        os_system_manager=FakeOSManager(),
+    )
+
+    monkeypatch.setattr(DriverManager, "_acquire_lock", staticmethod(lambda _path, timeout=60.0, poll_interval=0.1: 1))
+    monkeypatch.setattr(DriverManager, "_release_lock", staticmethod(lambda _fd, _path: None))
+
+    path = manager._get_driver_binary_path(FakeDriver())
+
+    assert path == "/tmp/cached/chromedriver"
+    assert cache.find_calls == 2
+    assert downloader.download_calls == 0
+    assert cache.saved is False

--- a/webdriver_manager/core/driver_cache.py
+++ b/webdriver_manager/core/driver_cache.py
@@ -44,6 +44,10 @@ class DriverCacheManager(object):
         if not self._file_manager:
             self._file_manager = FileManager(self._os_system_manager)
 
+    def get_driver_lock_path(self, driver_name: str, os_type: str) -> str:
+        os.makedirs(self._root_dir, exist_ok=True)
+        return os.path.join(self._root_dir, f".wdm-lock-{driver_name}-{os_type}")
+
     def save_archive_file(self, file: File, path):
         return self._file_manager.save_archive_file(file, path)
 

--- a/webdriver_manager/core/manager.py
+++ b/webdriver_manager/core/manager.py
@@ -2,6 +2,8 @@ from webdriver_manager.core.download_manager import WDMDownloadManager
 from webdriver_manager.core.driver_cache import DriverCacheManager
 from webdriver_manager.core.logger import log
 from webdriver_manager.core.os_manager import OperationSystemManager
+import os
+import time
 
 
 class DriverManager(object):
@@ -38,9 +40,39 @@ class DriverManager(object):
             return binary_path
 
         os_type = self.get_os_type()
-        file = self._download_manager.download_file(driver.get_driver_download_url(os_type))
-        binary_path = self._cache_manager.save_file_to_cache(driver, file)
-        return binary_path
+        lock_path = self._cache_manager.get_driver_lock_path(driver.get_name(), os_type)
+        lock_fd = self._acquire_lock(lock_path)
+        try:
+            # Re-check cache after lock to avoid duplicate downloads in concurrent runs.
+            binary_path = self._cache_manager.find_driver(driver)
+            if binary_path:
+                return binary_path
+
+            file = self._download_manager.download_file(driver.get_driver_download_url(os_type))
+            binary_path = self._cache_manager.save_file_to_cache(driver, file)
+            return binary_path
+        finally:
+            self._release_lock(lock_fd, lock_path)
 
     def get_os_type(self):
         return self._os_system_manager.get_os_type()
+
+    @staticmethod
+    def _acquire_lock(lock_path: str, timeout: float = 60.0, poll_interval: float = 0.1):
+        start = time.time()
+        while True:
+            try:
+                return os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_RDWR)
+            except FileExistsError:
+                if time.time() - start >= timeout:
+                    raise TimeoutError(f"Timed out waiting for webdriver-manager lock: {lock_path}")
+                time.sleep(poll_interval)
+
+    @staticmethod
+    def _release_lock(lock_fd, lock_path: str):
+        if lock_fd is not None:
+            os.close(lock_fd)
+        try:
+            os.unlink(lock_path)
+        except FileNotFoundError:
+            pass


### PR DESCRIPTION
`ChromeDriverManager().install()` could race under multiprocessing:
- multiple processes downloading/extracting the same driver simultaneously
- intermittent `zipfile.BadZipFile` and startup crashes
- redundant downloads despite cache

This PR adds concurrency protection:
1. Inter-process lock around the download+save critical section.
2. Cache re-check after acquiring lock (double-checked cache) to avoid duplicate work.
3. Regression test to ensure second check prevents unnecessary download when another process has already cached the driver.

This addresses the failure mode reported in:
- #700 (`BadZipFile` under concurrent install)
- #631 (multi-process crashes and duplicated downloads)